### PR TITLE
Enhancements for login and management pages

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -551,6 +551,31 @@ function listBoard(teacherCode) {
 }
 
 /**
+ * listTaskBoard(teacherCode, taskId):
+ * 指定課題の回答ログを新しい順に返す
+ */
+function listTaskBoard(teacherCode, taskId) {
+  const ss = getSpreadsheetByTeacherCode(teacherCode);
+  if (!ss) return [];
+  const sheet = ss.getSheetByName(SHEET_GLOBAL_ANSWERS);
+  if (!sheet) return [];
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return [];
+  const data = sheet.getRange(2, 1, lastRow - 1, 10).getValues();
+  const filtered = data.filter(r => r[2] === taskId).reverse();
+  return filtered.map(row => ({
+    studentId: row[1],
+    answer: row[3],
+    earnedXp: row[4],
+    totalXp: row[5],
+    level: row[6],
+    trophies: row[7],
+    aiCalls: row[8],
+    attempts: row[9]
+  }));
+}
+
+/**
  * getStatistics(teacherCode):
  * 課題数・生徒数を取得
  */
@@ -619,4 +644,24 @@ function logToSpreadsheet(logData) {
  */
 function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+
+/**
+ * Gemini 設定を保存
+ */
+function setGeminiSettings(apiKey, persona) {
+  const props = PropertiesService.getScriptProperties();
+  if (apiKey !== undefined) props.setProperty('GEMINI_API_KEY', apiKey);
+  if (persona !== undefined) props.setProperty('GEMINI_PERSONA', persona);
+}
+
+/**
+ * Gemini 設定を取得
+ */
+function getGeminiSettings() {
+  const props = PropertiesService.getScriptProperties();
+  return {
+    apiKey: props.getProperty('GEMINI_API_KEY') || '',
+    persona: props.getProperty('GEMINI_PERSONA') || ''
+  };
 }

--- a/board.html
+++ b/board.html
@@ -13,9 +13,9 @@
 </head>
 <body class="min-h-screen bg-gray-950 text-gray-100 p-4 md:p-6">
   <header class="mb-6 flex justify-between items-center">
-    <h1 class="text-2xl flex items-center gap-2">
+    <h1 id="boardHeading" class="text-2xl flex items-center gap-2">
       <svg data-icon="ClipboardList" class="w-6 h-6 text-pink-400"></svg>
-      みんなの回答ボード
+      <span id="boardHeadingText">みんなの回答ボード</span>
     </h1>
     <a href="#" id="backLink" class="text-sm hover:text-pink-400">&laquo; 管理パネルに戻る</a>
   </header>
@@ -25,15 +25,20 @@
     document.addEventListener('DOMContentLoaded', () => {
       const params = new URLSearchParams(location.search);
       const teacherCode = params.get('teacher');
+      const taskId = params.get('task');
       if (!teacherCode) {
         alert('不正なアクセスです。');
         location.href = '?page=login';
         return;
       }
       document.getElementById('backLink').href = `?page=manage&teacher=${encodeURIComponent(teacherCode)}`;
+      if (taskId) {
+        document.getElementById('boardHeadingText').textContent = '課題別ボード';
+      }
 
       function loadBoard() {
-        google.script.run.withSuccessHandler(renderBoard).listBoard(teacherCode);
+        const func = taskId ? 'listTaskBoard' : 'listBoard';
+        google.script.run.withSuccessHandler(renderBoard)[func](teacherCode, taskId);
       }
 
       function renderBoard(rows) {

--- a/login.html
+++ b/login.html
@@ -214,7 +214,7 @@
       document.getElementById('teacherCode').addEventListener('input', normalizeTeacherCode);
       document.getElementById('grade').addEventListener('input', e => { e.target.value = toHalf(e.target.value.replace(/[^0-9]/g,'')); });
       document.getElementById('number').addEventListener('input', e => { e.target.value = toHalf(e.target.value.replace(/[^0-9]/g,'')); });
-      document.getElementById('classroom').addEventListener('input', e => { e.target.value = toHalf(e.target.value).toUpperCase().replace(/[^A-Z]/g,''); });
+      // "組" は全角入力を許可し、Enter(送信)時に半角へ変換するため、リアルタイム変換は行わない
     });
 
     function toHalf(str) {
@@ -323,7 +323,7 @@
         const saved = localStorage.getItem('teacherCode');
         const teacherCode = (saved || document.getElementById('teacherCode').value).trim().toUpperCase();
         const grade = document.getElementById('grade').value.trim();
-        const classroom = document.getElementById('classroom').value.trim().toUpperCase();
+        const classroom = toHalf(document.getElementById('classroom').value.trim()).toUpperCase();
         const number = document.getElementById('number').value.trim();
 
         if (!teacherCode) {

--- a/manage.html
+++ b/manage.html
@@ -41,6 +41,24 @@
       </span>
     </div>
   </header>
+  <!-- Gemini 設定エリア -->
+  <section class="p-4 bg-gray-900 flex flex-col md:flex-row gap-4 items-end" id="geminiSettings">
+    <div class="flex-1">
+      <label for="apiKeySetting" class="text-xs">Gemini APIキー</label>
+      <input id="apiKeySetting" type="text" class="w-full mt-1 p-2 rounded bg-gray-700 focus:outline-none text-sm" />
+    </div>
+    <div>
+      <label for="personaSetting" class="text-xs">ペルソナ</label>
+      <select id="personaSetting" class="w-full mt-1 p-2 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
+        <option value="">-- 選択 --</option>
+        <option value="小学生向け">小学生向け</option>
+        <option value="中学生向け">中学生向け</option>
+        <option value="教師向け">教師向け</option>
+      </select>
+    </div>
+    <button id="saveGeminiBtn" class="px-4 py-2 bg-pink-600 hover:bg-pink-500 rounded-xl text-sm">保存</button>
+    <span id="geminiStatus" class="text-green-400 text-xs hidden">保存済み</span>
+  </section>
   <div id="teacherCodeModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
     <div id="teacherCodeModalText" class="bg-white text-black p-8 rounded-lg text-3xl font-bold"></div>
   </div>
@@ -118,19 +136,6 @@
             <input type="checkbox" id="selfEval" /> 自己評価を許可する
           </label>
 
-          <div>
-            <label for="apiKey" class="text-xs">■ Gemini APIキー</label>
-            <input id="apiKey" type="text" class="w-full mt-1 p-2 rounded bg-gray-700 focus:outline-none text-sm" />
-          </div>
-          <div>
-            <label for="persona" class="text-xs">□ ペルソナ選択</label>
-            <select id="persona" class="w-full mt-1 p-2 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
-              <option value="">-- 選択 --</option>
-              <option value="小学生向け">小学生向け</option>
-              <option value="中学生向け">中学生向け</option>
-              <option value="教師向け">教師向け</option>
-            </select>
-          </div>
 
           <!-- ■ 作成ボタン -->
           <button id="createBtn" type="submit"
@@ -203,6 +208,10 @@
         document.getElementById('teacherCodeModal').classList.add('hidden');
       });
 
+      // Gemini 設定読み込み
+      loadGeminiSettings();
+      document.getElementById('saveGeminiBtn').addEventListener('click', saveGeminiSettings);
+
       // 3) 回答タイプ選択時に optionsArea を表示／非表示
       Array.from(document.getElementsByName('ansType')).forEach(radio => {
         radio.addEventListener('change', e => {
@@ -231,7 +240,7 @@
         const subject = document.getElementById('subject').value;
         const q = document.getElementById('question').value.trim();
         const self = document.getElementById('selfEval').checked;
-        const persona = document.getElementById('persona').value;
+        const persona = document.getElementById('personaSetting').value;
         const checkedRadio = document.querySelector('input[name="ansType"]:checked');
         if (!checkedRadio) {
           alert('回答タイプを選択してください。');
@@ -313,6 +322,28 @@
           .getStatistics(teacherCode);
       }
 
+      // Gemini 設定を取得して表示
+      function loadGeminiSettings() {
+        google.script.run
+          .withSuccessHandler(data => {
+            document.getElementById('apiKeySetting').value = data.apiKey || '';
+            document.getElementById('personaSetting').value = data.persona || '';
+            document.getElementById('geminiStatus').classList.toggle('hidden', !data.apiKey);
+          })
+          .getGeminiSettings();
+      }
+
+      // Gemini 設定を保存
+      function saveGeminiSettings() {
+        const key = document.getElementById('apiKeySetting').value.trim();
+        const persona = document.getElementById('personaSetting').value;
+        google.script.run
+          .withSuccessHandler(() => {
+            document.getElementById('geminiStatus').classList.remove('hidden');
+          })
+          .setGeminiSettings(key, persona);
+      }
+
       // 9) フォームリセットヘルパー
       function resetForm() {
         document.getElementById('subject').value = '';
@@ -322,8 +353,6 @@
         document.getElementById('optionsArea').classList.add('hidden');
         resetOptionInputs();
         document.getElementById('selfEval').checked = false;
-        document.getElementById('apiKey').value = '';
-        document.getElementById('persona').value = '';
       }
 
       function resetOptionInputs() {
@@ -388,7 +417,7 @@
           }
 
           const card = document.createElement('div');
-          card.className = 'bg-gray-700 p-4 rounded-xl shadow transition-transform hover:scale-102 relative';
+          card.className = 'bg-gray-700 p-4 rounded-xl shadow transition-transform hover:scale-102 relative cursor-pointer';
           card.innerHTML = `
             ${detailHtml}
             <p class="text-xs text-gray-400 mt-2">${x.date}</p>
@@ -396,6 +425,11 @@
               <svg data-icon="Trash2" class="w-4 h-4"></svg>
             </button>
           `;
+          card.addEventListener('click', e => {
+            if (!e.target.closest('.deleteBtn')) {
+              location.href = `?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${x.id}`;
+            }
+          });
           container.appendChild(card);
         });
 


### PR DESCRIPTION
## Summary
- allow full-width input for class on login and convert to half-width at submit
- add persistent Gemini API and persona settings in teacher panel
- enable task cards to open board view filtered by task
- support task filtering on board page
- implement API for saving Gemini settings and board filtering

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68413652cc40832b9cf8cbbf3ef2b384