### PR TITLE
Fix GAS deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,16 @@
+---
 name: Deploy GAS
 
-on:
+'on':
   push:
     branches:
       - main
+  workflow_dispatch: {}
+
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      GCP_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-      SCRIPT_ID:      ${{ secrets.SCRIPT_ID }}
     steps:
 
       - name: Check out repository
@@ -25,11 +25,18 @@ jobs:
         run: npm install --global @google/clasp@3.0.6-alpha
 
       - name: Restore GCP service-account key
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
         run: |
-          echo "$GCP_CREDENTIALS" | base64 -d > "$HOME/gcp-sa.json"
+          echo "$GOOGLE_CREDENTIALS" | base64 -d > "$HOME/gcp-sa.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcp-sa.json" >> $GITHUB_ENV
 
+      - name: Authenticate with clasp
+        run: clasp login --creds "$HOME/gcp-sa.json"
+
       - name: Write .clasp.json
+        env:
+          SCRIPT_ID: ${{ secrets.SCRIPT_ID }}
         run: |
           echo "{\"scriptId\":\"$SCRIPT_ID\"}" > .clasp.json
 

--- a/README.md
+++ b/README.md
@@ -470,3 +470,11 @@ StudyQuest（仮称）– 小学校向けゲーミフィケーション型課題
 * **各クラス用スプレッドシート名**： `StudyQuest_<teacherCode>_Grade<学年>_Class<組>_Log`
 * **シート一覧**（各クラス用シート共通）：
 # テストコミット #午後
+
+### GitHub ActionsによるGASデプロイ
+
+`.github/workflows/deploy.yml` では `main` ブランチへの push または手動実行で `clasp push` を行います。事前に次のシークレットを設定してください。
+
+- `GOOGLE_CREDENTIALS` – サービスアカウントJSONを base64 エンコードした文字列
+- `SCRIPT_ID` – デプロイ先の Apps Script プロジェクトID
+


### PR DESCRIPTION
## Summary
- update GitHub Actions to restore credentials per-step and login with `clasp`
- document required GitHub secrets

## Testing
- `yamllint .github/workflows/deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_6841d5909358832bb9770d3911c842df