### PR TITLE
Improve deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,71 +8,50 @@ on:
 jobs:
   deploy-gas:
     name: Deploy GAS via clasp
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
 
     env:
       # GitHub リポジトリのシークレットとして登録済みの変数
-      # - secrets.GOOGLE_CREDENTIALS : Base64 化されたサービスアカウント JSON
+      # - secrets.GOOGLE_CREDENTIALS : サービスアカウント JSON (auth ステップで使用)
       # - secrets.SCRIPT_ID          : デプロイ対象の Apps Script プロジェクトの Script ID
-      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-      SCRIPT_ID:          ${{ secrets.SCRIPT_ID }}
+      SCRIPT_ID: ${{ secrets.SCRIPT_ID }}
 
     steps:
       # 1) ソースコードをチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      # 2) Node.js をセットアップ（clasp は Node.js 上のツールなので必要）
-      - name: Setup Node.js (v20.x)
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
         with:
-          node-version: "20.x"
-        # ※ 以降のステップで env.GOOGLE_CREDENTIALS / env.SCRIPT_ID はそのまま参照できます
+          fetch-depth: 1
+        
+      # 2) Node.js をセットアップ（clasp は Node.js 上のツールなので必要）
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+        # ※ 以降のステップで env.SCRIPT_ID はそのまま参照できます
 
-      # 3) clasp をインストール（最新の安定版を指定）
+      # 3) Google への認証
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      # 4) clasp をインストール（最新の安定版を指定）
       - name: Install clasp (stable)
         run: npm install --global @google/clasp@latest
 
-      # 4) サービスアカウント JSON を復元し、Application Default Credentials（ADC）を有効化
-      - name: Authenticate with Google (ADC)
-        run: |
-          # --- サービスアカウント JSON を一時ディレクトリに出力 ---
-          mkdir -p "$HOME/.config/gcloud"
-          echo "${GOOGLE_CREDENTIALS}" | base64 -d > "$HOME/.config/gcloud/service-account.json"
 
-          # --- 環境変数を設定（以降のステップで自動的に読み込まれる） ---
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/service-account.json" >> $GITHUB_ENV
-
-          # --- gcloud コマンドをインストールしている場合は、サービスアカウントで認証してもよい（オプション） ---
-          #  gcloud auth activate-service-account --key-file="$HOME/.config/gcloud/service-account.json"
-        env:
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-
-      # 5) 認証状況を確認（Apps Script API が有効か、サービスアカウントで認証できているか）
-      #    もし gcloud CLI がインストールされていない場合は飛ばしてもかまいませんが、CI 上で動作確認するなら入れておくと安心です。
-      - name: Verify Google Authentication (optional)
-        if: always()
-        run: |
-          echo "=== Verify that ADC is active ==="
-          # gcloud CLI が使えるなら…
-          if command -v gcloud &> /dev/null; then
-            gcloud auth list --filter="status:ACTIVE" --format="table(account)"
-            gcloud services list --enabled --filter="name:script.googleapis.com"
-          else
-            echo "gcloud CLI not found; skipping detailed checks"
-          fi
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
-
-      # 6) .clasp.json を書き込み（SCRIPT_ID を設定）
+      # 5) .clasp.json を書き込み（SCRIPT_ID を設定）
       - name: Write .clasp.json
         run: |
           echo "{\"scriptId\":\"${SCRIPT_ID}\"}" > .clasp.json
-        env:
-          SCRIPT_ID: ${{ env.SCRIPT_ID }}
 
-      # 7) デバッグ用のログ出力（念のためディレクトリ・ファイル構造や環境変数を表示）
+      # 6) デバッグ用のログ出力（念のためディレクトリ・ファイル構造や環境変数を表示）
       - name: Debug: List files and verify .clasp.json
+        if: failure()
         run: |
           echo "Current directory: $(pwd)"
           echo "Files in current directory:"
@@ -84,13 +63,9 @@ jobs:
 
           echo ""
           echo "GOOGLE_APPLICATION_CREDENTIALS: $GOOGLE_APPLICATION_CREDENTIALS"
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
 
-      # 8) clasp push で Apps Script にデプロイ
+      # 7) clasp push で Apps Script にデプロイ
       - name: Push to Apps Script
         run: |
           echo "=== Deploying to Apps Script via clasp ==="
           clasp push --force --adc
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}


### PR DESCRIPTION
## Summary
- streamline credentials setup using `google-github-actions/auth`
- run on `ubuntu-latest` and cancel redundant deployments
- upgrade checkout and Node setup actions
- reduce output logging and run debug step only on failure

## Testing
- `yamllint .github/workflows/deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_684270daaebc832bb79793346215082f