### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ steps.auth.outputs.project_id }}
+
       # 認証情報からプロジェクトIDとサービスアカウントを環境変数に設定
       - name: Export env vars
         run: |


### PR DESCRIPTION
## Summary
- install Google Cloud SDK before running debug scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684288281fd0832bad2482cb4a9953dc