### PR TITLE
Escape user data in board and input pages

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -22,6 +22,15 @@
   <div class="grid gap-4" id="answers" style="grid-template-columns:repeat(auto-fill,minmax(240px,1fr));"></div>
 
   <script>
+    function escapeHtml(text) {
+      return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const params = new URLSearchParams(location.search);
       const teacherCode = params.get('teacher');
@@ -52,11 +61,11 @@
           const card = document.createElement('div');
           card.className = 'p-4 bg-gray-800 rounded-xl shadow-md break-words opacity-0';
           card.innerHTML = `
-            <h3 class="text-pink-400 text-sm mb-1">${r.studentId}</h3>
-            <p class="text-gray-200 whitespace-pre-wrap">${r.answer}</p>
-            <p class="text-xs text-gray-400 mt-2">XP: ${r.earnedXp} (累計 ${r.totalXp}) Lv${r.level}</p>
-            <p class="text-xs text-gray-400">トロフィー: ${r.trophies}</p>
-            <p class="text-xs text-gray-400">AIヒント: ${r.aiCalls}/2 回, 回答: ${r.attempts}/3 回</p>
+            <h3 class="text-pink-400 text-sm mb-1">${escapeHtml(r.studentId)}</h3>
+            <p class="text-gray-200 whitespace-pre-wrap">${escapeHtml(r.answer)}</p>
+            <p class="text-xs text-gray-400 mt-2">XP: ${escapeHtml(r.earnedXp)} (累計 ${escapeHtml(r.totalXp)}) Lv${escapeHtml(r.level)}</p>
+            <p class="text-xs text-gray-400">トロフィー: ${escapeHtml(r.trophies)}</p>
+            <p class="text-xs text-gray-400">AIヒント: ${escapeHtml(r.aiCalls)}/2 回, 回答: ${escapeHtml(r.attempts)}/3 回</p>
           `;
           container.appendChild(card);
           // カードが順番に回転しながらフェードイン

--- a/src/input.html
+++ b/src/input.html
@@ -151,6 +151,15 @@
   </script>
 
   <script>
+    function escapeHtml(text) {
+      return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     // Lucide Icons のレンダリング
     function renderIcons(scope) {
       scope.querySelectorAll('[data-icon]').forEach(el => {
@@ -299,8 +308,8 @@
           const item = document.createElement('div');
           item.className = 'bg-gray-700 p-3 rounded-md cursor-pointer hover:bg-gray-600';
           item.innerHTML = `
-            <p class="text-sm mb-1 text-white">【${parsed.subject || '無題'}】 ${parsed.question || '(質問なし)'}</p>
-            <p class="text-xs text-gray-300">${q.date}</p>
+            <p class="text-sm mb-1 text-white">【${escapeHtml(parsed.subject || '無題')}】 ${escapeHtml(parsed.question || '(質問なし)')}</p>
+            <p class="text-xs text-gray-300">${escapeHtml(q.date)}</p>
           `;
           item.addEventListener('click', () => showQuestDetail(q, false, historyRows));
           ulUn.appendChild(item);
@@ -323,8 +332,8 @@
           const item = document.createElement('div');
           item.className = 'bg-gray-700 p-3 rounded-md cursor-pointer hover:bg-gray-600';
           item.innerHTML = `
-            <p class="text-sm line-through opacity-70 text-gray-300">【${parsed.subject || '無題'}】 ${parsed.question || '(質問なし)'}</p>
-            <p class="text-xs text-gray-400">${q.date}</p>
+            <p class="text-sm line-through opacity-70 text-gray-300">【${escapeHtml(parsed.subject || '無題')}】 ${escapeHtml(parsed.question || '(質問なし)')}</p>
+            <p class="text-xs text-gray-400">${escapeHtml(q.date)}</p>
           `;
           item.addEventListener('click', () => showQuestDetail(q, true, historyRows));
           ulAn.appendChild(item);
@@ -346,7 +355,7 @@
 
       const detail = document.getElementById('detailContent');
       detail.innerHTML = `
-        <h3 class="text-lg font-bold mb-2 text-white">【${parsed.subject || '無題'}】 ${parsed.question || '(質問なし)'}</h3>
+        <h3 class="text-lg font-bold mb-2 text-white">【${escapeHtml(parsed.subject || '無題')}】 ${escapeHtml(parsed.question || '(質問なし)')}</h3>
         <div id="formArea" class="mt-2">
           <textarea id="detailAnswer" placeholder="ここに回答を入力…" class="w-full p-2 bg-gray-600 rounded text-sm text-gray-100 placeholder-gray-400"></textarea>
           <div class="mt-2 flex gap-2">
@@ -444,8 +453,8 @@
           const div = document.createElement('div');
           div.className = 'bg-gray-700 p-2 rounded mb-1';
           div.innerHTML = `
-            <p class="text-xs text-gray-400">${new Date(r[0]).toLocaleString()}</p>
-            <p class="text-sm text-gray-100">${r[3]}</p>
+            <p class="text-xs text-gray-400">${escapeHtml(new Date(r[0]).toLocaleString())}</p>
+            <p class="text-sm text-gray-100">${escapeHtml(r[3])}</p>
           `;
           container.appendChild(div);
         });


### PR DESCRIPTION
## Summary
- add `escapeHtml` helper to HTML pages
- sanitize user generated content when rendering board cards and quest details

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1dac754832b862010f1675cb1e8