### PR TITLE
Fix clasp deploy step for old versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,19 @@ jobs:
           echo "→ 新しいバージョン番号: $NEW_VER"
 
           # 3) “既存”のウェブアプリ (DEPLOYMENT_ID) に上書きデプロイ
-          clasp deploy \
-            --deploymentId "${DEPLOYMENT_ID}" \
-            --versionNumber "${NEW_VER}" \
-            --description "auto-deploy from GitHub Actions"
+          if clasp deploy --help | grep -q -- '--type'; then
+            clasp deploy \
+              --deploymentId "${DEPLOYMENT_ID}" \
+              --versionNumber "${NEW_VER}" \
+              --description "auto-deploy from GitHub Actions" \
+              --type webapp
+          else
+            # 古い clasp は --type 未対応
+            clasp deploy \
+              --deploymentId "${DEPLOYMENT_ID}" \
+              --versionNumber "${NEW_VER}" \
+              --description "auto-deploy from GitHub Actions"
+          fi
 
           # 4) 固定URLに ?page=login を付けて出力
           FINAL_URL="https://script.google.com/macros/s/${DEPLOYMENT_ID}/exec?page=login"

--- a/README.md
+++ b/README.md
@@ -484,3 +484,4 @@ StudyQuest（仮称）– 小学校向けゲーミフィケーション型課題
 1. `CLASPRC_JSON` と `DEPLOYMENT_ID` をリポジトリのシークレットに登録します。
 2. `main` ブランチへ push するとワークフローが走り、`clasp push` と `clasp deploy` が自動実行されます。
 3. 完了後、ログに `https://script.google.com/macros/s/<DEPLOYMENT_ID>/exec?page=login` の形式で公開 URL が表示されます。
+4. 初回のみ Apps Script エディタから Web アプリを手動作成し、得られた `DEPLOYMENT_ID` をシークレットに登録してください。`appsscript.json` に `webapp` 設定を追記します。使用している `clasp` が `--type` オプションをサポートしている場合は `clasp deploy --type webapp` と指定しますが、古いバージョンでは未対応のため省略しても構いません。

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -3,4 +3,8 @@
   "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"
+  ,"webapp": {
+    "access": "ANYONE",
+    "executeAs": "USER_ACCESSING"
+  }
 }


### PR DESCRIPTION
## Summary
- add fallback when `clasp deploy --type` option is unavailable
- document optional `--type` usage in README

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68436c4300c8832b9488332b0e65958b