### PR TITLE
Fix login redirect and submission issues

### DIFF
--- a/src/input.html
+++ b/src/input.html
@@ -394,7 +394,7 @@
       // 送信ボタンにイベント設定
       document.getElementById('submitBtn').addEventListener('click', () => {
         const text = document.getElementById('detailAnswer').value.trim();
-        submitAnswer(task.id, text);
+        submitAnswer(task.id, text, userSubs.length + 1);
       });
       debug('  [画面上] 送信ボタンに click イベントを設定');
 
@@ -419,7 +419,7 @@
     }
 
     // ─── 回答を送信（複数回OK） ───
-    function submitAnswer(taskId, text) {
+    function submitAnswer(taskId, text, attemptCount) {
       if (!text) {
         debug('⚠️ 送信エラー: 回答が空です');
         return;
@@ -448,7 +448,7 @@
         .withFailureHandler(err => {
           debug(`❌ submitAnswer エラー: ${err.message || JSON.stringify(err)}`);
         })
-        .submitAnswer(teacherCode, studentId, taskId, text, xpPerQuest, totalXp + xpPerQuest, level, '', 0, userSubs.length + 1);
+        .submitAnswer(teacherCode, studentId, taskId, text, xpPerQuest, totalXp + xpPerQuest, level, '', 0, attemptCount);
     }
 
     // ─── 提出履歴モーダルを表示 ───

--- a/src/login.html
+++ b/src/login.html
@@ -127,8 +127,7 @@
 
   <!-- exec URL を埋め込む -->
   <script>
-    // TODO: Set the correct script URL here
-    const SCRIPT_URL = '';
+    const SCRIPT_URL = '<?!= scriptUrl.replace("/dev", "/exec") ?>';
   </script>
 
   <script>

--- a/src/manage.html
+++ b/src/manage.html
@@ -28,6 +28,7 @@
     </h1>
     <div class="flex items-center gap-4">
       <a id="boardLink" href="#" class="text-sm hover:text-pink-400">回答ボードを見る</a>
+      <a id="backToLogin" href="?page=login" class="text-sm hover:text-pink-400">ログイン画面へ</a>
       <span id="codeBadge" class="px-3 py-1 bg-pink-600 rounded-xl text-sm tracking-wider">
         <!-- ここに CODE: XXXX が入る -->
       </span>
@@ -45,7 +46,7 @@
   <section class="p-4 bg-gray-900 flex flex-col md:flex-row gap-4 items-end" id="geminiSettings">
     <div class="flex-1">
       <label for="apiKeySetting" class="text-xs">Gemini APIキー</label>
-      <input id="apiKeySetting" type="text" class="w-full mt-1 p-2 rounded bg-gray-700 focus:outline-none text-sm" />
+      <input id="apiKeySetting" type="password" class="w-full mt-1 p-2 rounded bg-gray-700 focus:outline-none text-sm" placeholder="保存済みの場合は空白" />
     </div>
     <div>
       <label for="personaSetting" class="text-xs">ペルソナ</label>
@@ -326,7 +327,14 @@
       function loadGeminiSettings() {
         google.script.run
           .withSuccessHandler(data => {
-            document.getElementById('apiKeySetting').value = data.apiKey || '';
+            const keyInput = document.getElementById('apiKeySetting');
+            if (data.apiKey) {
+              keyInput.value = '';
+              keyInput.placeholder = '********';
+            } else {
+              keyInput.value = '';
+              keyInput.placeholder = '';
+            }
             document.getElementById('personaSetting').value = data.persona || '';
             document.getElementById('geminiStatus').classList.toggle('hidden', !data.apiKey);
           })


### PR DESCRIPTION
## Summary
- ensure login page always redirects to the deployed `exec` URL
- hide Gemini API key and add link back to login page in manage panel
- pass attempt count when students submit answers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684372d1d974832b9ab5a6070ccd35af