### PR TITLE
Display script version on every page

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -11,6 +11,7 @@ const SHEET_AI_FEEDBACK     = 'AIフィードバックログ';
 const STUDENT_SHEET_PREFIX  = '生徒_'; // 生徒_<ID> 形式の個別シートを想定
 
 const FOLDER_NAME_PREFIX    = 'StudyQuest_';
+const GAS_VERSION           = 'v1.0.0';
 
 /**
  * doGet(e): テンプレートにパラメータを埋め込んで返す
@@ -23,6 +24,7 @@ function doGet(e) {
   template.grade       = (e && e.parameter && e.parameter.grade)     ? e.parameter.grade     : '';
   template.classroom   = (e && e.parameter && e.parameter['class'])  ? e.parameter['class']  : '';
   template.number      = (e && e.parameter && e.parameter.number)    ? e.parameter.number    : '';
+  template.version     = getGasVersion();
   return template
     .evaluate()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
@@ -664,4 +666,11 @@ function getGeminiSettings() {
     apiKey: props.getProperty('GEMINI_API_KEY') || '',
     persona: props.getProperty('GEMINI_PERSONA') || ''
   };
+}
+
+/**
+ * 現在の GAS バージョンを返す
+ */
+function getGasVersion() {
+  return GAS_VERSION;
 }

--- a/src/board.html
+++ b/src/board.html
@@ -95,5 +95,8 @@
       setInterval(loadBoard, 15000);
     });
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400">GAS v<?= version ?></div>
 </body>
 </html>

--- a/src/input.html
+++ b/src/input.html
@@ -557,5 +557,8 @@
       requestAnimationFrame(animateParticles);
     }
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400">GAS v<?= version ?></div>
 </body>
 </html>

--- a/src/login.html
+++ b/src/login.html
@@ -395,5 +395,8 @@
     }
   </script>
 
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400">GAS v<?= version ?></div>
+
 </body>
 </html>

--- a/src/manage.html
+++ b/src/manage.html
@@ -473,5 +473,8 @@
       gsap.from('main', { opacity: 0, y: 20, duration: 0.6 });
     });
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400">GAS v<?= version ?></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track GAS version with a constant and helper in Code.gs
- expose the version to HTML templates
- show the current version at the bottom-right of login, input, board and manage pages

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_684384f12bac832b96fbc0111bafc6ad