### PR TITLE
Display test version string

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -11,6 +11,8 @@ const SHEET_AI_FEEDBACK     = 'AIフィードバックログ';
 const STUDENT_SHEET_PREFIX  = '生徒_'; // 生徒_<ID> 形式の個別シートを想定
 
 const FOLDER_NAME_PREFIX    = 'StudyQuest_';
+// GAS スクリプトのテストバージョン
+const GAS_VERSION           = '0.1.0-test';
 
 /**
  * doGet(e): テンプレートにパラメータを埋め込んで返す
@@ -23,6 +25,7 @@ function doGet(e) {
   template.grade       = (e && e.parameter && e.parameter.grade)     ? e.parameter.grade     : '';
   template.classroom   = (e && e.parameter && e.parameter['class'])  ? e.parameter['class']  : '';
   template.number      = (e && e.parameter && e.parameter.number)    ? e.parameter.number    : '';
+  template.version     = getGasVersion();
   return template
     .evaluate()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
@@ -664,4 +667,11 @@ function getGeminiSettings() {
     apiKey: props.getProperty('GEMINI_API_KEY') || '',
     persona: props.getProperty('GEMINI_PERSONA') || ''
   };
+}
+
+/**
+ * 現在の GAS バージョンを返す
+ */
+function getGasVersion() {
+  return `GAS v${GAS_VERSION}`;
 }

--- a/src/board.html
+++ b/src/board.html
@@ -95,5 +95,8 @@
       setInterval(loadBoard, 15000);
     });
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400"><?= version ?></div>
 </body>
 </html>

--- a/src/input.html
+++ b/src/input.html
@@ -557,5 +557,8 @@
       requestAnimationFrame(animateParticles);
     }
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400"><?= version ?></div>
 </body>
 </html>

--- a/src/login.html
+++ b/src/login.html
@@ -395,5 +395,8 @@
     }
   </script>
 
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400"><?= version ?></div>
+
 </body>
 </html>

--- a/src/manage.html
+++ b/src/manage.html
@@ -473,5 +473,8 @@
       gsap.from('main', { opacity: 0, y: 20, duration: 0.6 });
     });
   </script>
+
+  <!-- バージョン表示 -->
+  <div class="fixed bottom-2 right-2 text-xs text-gray-400"><?= version ?></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track GAS script test version
- show the version string from a helper function on every template

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684384f12bac832b96fbc0111bafc6ad