### PR TITLE
Automate version bump on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,5 +44,19 @@ jobs:
           echo "webapp_url=https://script.google.com/macros/s/${DEPLOYMENT_ID}/exec?page=login" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Show URL
-        run: echo "${{ steps.deploy.outputs.webapp_url }}"
+        - name: Show URL
+          run: echo "${{ steps.deploy.outputs.webapp_url }}"
+
+        - name: Bump version and commit
+          if: success()
+          run: |
+            set -eux
+            npm version patch --no-git-tag-version
+            NEW_VER=$(node -p "require('./package.json').version")
+            sed -i "s/^const SQ_VERSION           = 'v[0-9.]*';$/const SQ_VERSION           = 'v${NEW_VER}';/" src/Code.gs
+            sed -i "s/expect(getSqVersion()).toBe('v[0-9.]*');/expect(getSqVersion()).toBe('v${NEW_VER}');/" tests/Code.test.js
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add package.json src/Code.gs tests/Code.test.js
+            git commit -m "Bump version to v${NEW_VER}"
+            git push

--- a/README.md
+++ b/README.md
@@ -484,4 +484,5 @@ StudyQuest（仮称）– 小学校向けゲーミフィケーション型課題
 1. `CLASPRC_JSON` と `DEPLOYMENT_ID` をリポジトリのシークレットに登録します。
 2. `main` ブランチへ push するとワークフローが走り、`clasp push` と `clasp deploy` が自動実行されます。
 3. 初回のみ Apps Script エディタから Web アプリを手動作成し、得られた `DEPLOYMENT_ID` をシークレットに登録してください。`appsscript.json` に `webapp` 設定を追記します。
+4. デプロイ完了後、ワークフローは `package.json` のパッチバージョンを更新し、`src/Code.gs` とテストへ反映した上で自動コミット・プッシュします。
 


### PR DESCRIPTION
## Summary
- add step in deploy.yml to bump version after deployment
- document automatic version updates in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684393ea6bc8832b8b5a68f7ce12a038