### PR TITLE
Update manage buttons

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -433,12 +433,14 @@
           card.innerHTML = `
             ${detailHtml}
             <p class="text-sm text-gray-400 mt-2">${x.date}</p>
-            <button class="copyBtn absolute top-2 right-12 bg-indigo-600 hover:bg-indigo-500 text-white p-1 rounded" data-id="${x.id}">
-              <svg data-icon="Copy" class="w-4 h-4"></svg>
-            </button>
-            <button class="deleteBtn absolute top-2 right-2 bg-red-600 hover:bg-red-500 text-white p-1 rounded" data-id="${x.id}">
-              <svg data-icon="Trash2" class="w-4 h-4"></svg>
-            </button>
+            <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2">
+              <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
+                <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
+              </button>
+              <button class="deleteBtn p-1" data-id="${x.id}" title="この課題を削除">
+                <i data-icon="Trash2" class="w-6 h-6 text-red-400"></i>
+              </button>
+            </div>
           `;
           card.addEventListener('click', e => {
             if (!e.target.closest('.deleteBtn') && !e.target.closest('.copyBtn')) {


### PR DESCRIPTION
## Summary
- arrange task card buttons vertically
- tweak icon sizes for copy/delete actions
- center the button stack on the card's edge

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684392fa8204832b9aa5dd291c2d896b