### PR TITLE
Fix icon rendering for task cards

### DIFF
--- a/src/input.html
+++ b/src/input.html
@@ -162,12 +162,13 @@
 
     // Lucide Icons のレンダリング
     function renderIcons(scope) {
-      scope.querySelectorAll('[data-icon]').forEach(el => {
-        const iconName = el.getAttribute('data-icon');
-        if (window.lucide && typeof window.lucide[iconName] === 'function') {
-          el.innerHTML = window.lucide[iconName]().outerHTML;
-        }
-      });
+      if (window.lucide && typeof window.lucide.createIcons === 'function') {
+        window.lucide.createIcons({
+          nameAttr: 'data-icon',
+          attrs: {},
+          icons: window.lucide.icons
+        });
+      }
     }
 
     // デバッグログ出力用

--- a/src/manage.html
+++ b/src/manage.html
@@ -169,14 +169,15 @@
 <script src="https://cdn.jsdelivr.net/npm/lucide@0.259.0/dist/umd/lucide.min.js"></script>
 
   <script>
-    // Lucide Icons を実際に SVG に置き換え
+    // Lucide Icons を SVG に置き換える
     function renderIcons(scope) {
-      scope.querySelectorAll('[data-icon]').forEach(el => {
-        const iconName = el.getAttribute('data-icon');
-        if (window.lucide && typeof window.lucide[iconName] === 'function') {
-          el.innerHTML = window.lucide[iconName]().outerHTML;
-        }
-      });
+      if (window.lucide && typeof window.lucide.createIcons === 'function') {
+        window.lucide.createIcons({
+          nameAttr: 'data-icon',
+          attrs: {},
+          icons: window.lucide.icons
+        });
+      }
     }
 
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- ensure lucide icons are replaced using `createIcons`
- do the same for student task board

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843a86f2c0c832b8969f0b4c1c36148