### PR TITLE
Add folder initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "studyquest",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studyquest",
-      "version": "1.0.0",
+      "version": "1.0.6",
       "devDependencies": {
         "@google/clasp": "^2.4.2",
         "jest": "^29.7.0"


### PR DESCRIPTION
## Summary
- initialize per-class folders with `initializeFolders`
- call folder initializer when creating a new teacher code

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843c0927d78832bbacc2f173c650ad6