### PR TITLE
Fix spreadsheet scope and store settings in Drive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "studyquest",
-  "version": "1.0.6",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studyquest",
-      "version": "1.0.6",
+      "version": "1.0.12",
       "devDependencies": {
         "@google/clasp": "^2.4.2",
         "jest": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studyquest",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "scripts": {
     "deploy": "clasp push --force --no-open",

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -17,6 +17,7 @@
   },
   "oauthScopes": [
     "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/drive"
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/spreadsheets"
   ]
 }

--- a/src/input.html
+++ b/src/input.html
@@ -414,7 +414,7 @@
           .withFailureHandler(err => {
             alert('AIフィードバック取得失敗: ' + err.message);
           })
-          .callGeminiAPI_GAS(`回答: ${text}`, '小学生向け');
+          .callGeminiAPI_GAS(teacherCode, `回答: ${text}`, '小学生向け');
       });
       debug('  [画面上] AIボタンに click イベントを設定');
     }

--- a/src/manage.html
+++ b/src/manage.html
@@ -66,10 +66,11 @@
     <div id="teacherCodeModalText" class="bg-white text-black p-8 rounded-lg text-6xl font-bold text-center tracking-widest"></div>
   </div>
   <div id="classSettingModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
-    <div class="bg-gray-800 text-gray-200 p-6 rounded-xl space-y-4 w-72">
-      <p class="text-sm">クラスIDを「学年,組;学年,組」の形式で入力 (最大8件)</p>
-      <textarea id="classIdInput" rows="3" class="w-full p-2 rounded bg-gray-700 focus:outline-none text-sm" placeholder="例: 6,1;6,2"></textarea>
-      <div class="flex justify-end gap-2">
+    <div class="bg-gray-800 text-gray-200 p-6 rounded-xl space-y-4 w-80">
+      <p class="text-sm">担当クラスを追加 (最大8件)</p>
+      <div id="classListArea" class="space-y-2"></div>
+      <button id="addClassRow" class="px-2 py-1 bg-gray-700 rounded text-xs">+ 追加</button>
+      <div class="flex justify-end gap-2 pt-2">
         <button id="cancelClassBtn" class="px-3 py-1 bg-gray-600 rounded text-sm">キャンセル</button>
         <button id="confirmClassBtn" class="px-3 py-1 bg-pink-600 hover:bg-pink-500 rounded text-sm">保存</button>
       </div>
@@ -213,15 +214,43 @@
       // Gemini 設定読み込み
       loadGeminiSettings();
       document.getElementById('saveGeminiBtn').addEventListener('click', saveGeminiSettings);
+      function renderClassRows(list) {
+        const area = document.getElementById('classListArea');
+        area.innerHTML = '';
+        if (!list || !list.length) list = [['','']];
+        list.forEach(item => addRow(item[0], item[1]));
+      }
+      function addRow(g='', c='') {
+        const area = document.getElementById('classListArea');
+        const div = document.createElement('div');
+        div.className = 'flex gap-2';
+        div.innerHTML = `
+          <input type="number" class="w-14 p-1 rounded bg-gray-700 text-sm" placeholder="学年" value="${g}">
+          <input type="text" class="w-14 p-1 rounded bg-gray-700 text-sm" placeholder="組" value="${c}">
+          <button type="button" class="removeRow px-2 bg-gray-600 rounded text-xs">&#8722;</button>
+        `;
+        div.querySelector('.removeRow').onclick = () => div.remove();
+        area.appendChild(div);
+      }
+      document.getElementById('addClassRow').addEventListener('click', () => addRow());
       document.getElementById('classSettingBtn').addEventListener('click', () => {
-        document.getElementById('classSettingModal').classList.remove('hidden');
+        google.script.run.withSuccessHandler(map => {
+          const list = Object.keys(map).map(id => map[id].split('-'));
+          renderClassRows(list);
+          document.getElementById('classSettingModal').classList.remove('hidden');
+        }).getClassIdMap_(teacherCode);
       });
       document.getElementById('cancelClassBtn').addEventListener('click', () => {
         document.getElementById('classSettingModal').classList.add('hidden');
       });
       document.getElementById('confirmClassBtn').addEventListener('click', () => {
-        const input = document.getElementById('classIdInput').value.trim();
-        if (input.split(';').filter(x => x.trim()).length > 8) {
+        const rows = Array.from(document.querySelectorAll('#classListArea div'));
+        const list = rows.map(div => {
+          const g = div.children[0].value.trim();
+          const c = div.children[1].value.trim();
+          return g && c ? [g,c] : null;
+        }).filter(Boolean);
+        if (list.length > 8) {
           alert('最大8件まで入力できます。');
           return;
         }
@@ -230,7 +259,7 @@
             document.getElementById('classSettingModal').classList.add('hidden');
           })
           .withFailureHandler(err => alert('更新に失敗: ' + err.message))
-          .setClassIdMap(teacherCode, input);
+          .setClassIdMap(teacherCode, list.map(p => p.join(',')).join(';'));
       });
 
       // 3) 回答タイプ選択時に optionsArea を表示／非表示
@@ -373,7 +402,7 @@
             document.getElementById('personaSetting').value = data.persona || '';
             document.getElementById('geminiStatus').classList.toggle('hidden', !data.apiKey);
           })
-          .getGeminiSettings();
+          .getGeminiSettings(teacherCode);
       }
 
       // Gemini 設定を保存
@@ -384,7 +413,7 @@
           .withSuccessHandler(() => {
             document.getElementById('geminiStatus').classList.remove('hidden');
           })
-          .setGeminiSettings(key, persona);
+          .setGeminiSettings(teacherCode, key, persona);
       }
 
       // 9) フォームリセットヘルパー

--- a/tests/Code.test.js
+++ b/tests/Code.test.js
@@ -1,5 +1,5 @@
 const { getSqVersion } = require('../src/Code.gs');
 
 test('getSqVersion returns correct version', () => {
-  expect(getSqVersion()).toBe('v1.0.11');
+  expect(getSqVersion()).toBe('v1.0.12');
 });


### PR DESCRIPTION
## Summary
- add spreadsheets OAuth scope
- store class maps and Gemini API settings in Drive instead of script properties
- support per-teacher Gemini settings
- enhance class setting UI on manage page
- bump version to v1.0.12

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843d62544e0832bafe138288cec0bdb