### PR TITLE
Improve folder detection for teachers

### DIFF
--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -19,7 +19,7 @@ function generateTeacherCode() {
  * 同名フォルダが複数ある場合、作成日が最新のものを返す
  */
 function findLatestFolderByName_(name) {
-  const q = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+  const q = `'root' in parents and name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
   try {
     const res = Drive.Files.list({ q, orderBy: 'createdTime desc', maxResults: 1 });
     const items = res.items || [];
@@ -62,6 +62,11 @@ function initTeacher(passcode) {
     return { status: 'error', message: 'パスコードが違います。' };
   }
   const props = PropertiesService.getScriptProperties();
+  const info = detectTeacherFolderOnDrive_();
+  if (info) {
+    props.setProperty(info.code, info.id);
+    return { status: 'ok', teacherCode: info.code };
+  }
   const existingCodes = props.getKeys().filter(key => key.match(/^[A-Z0-9]{6}$/));
   let foundCode = null;
   let foundDate = null;
@@ -75,13 +80,6 @@ function initTeacher(passcode) {
       }
     }
   });
-  if (!foundCode) {
-    const info = detectTeacherFolderOnDrive_();
-    if (info) {
-      props.setProperty(info.code, info.id);
-      return { status: 'ok', teacherCode: info.code };
-    }
-  }
   if (foundCode) {
     return { status: 'ok', teacherCode: foundCode };
   }

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadTeacher(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Teacher.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('initTeacher detects existing folder when script properties empty', () => {
+  const props = {};
+  const context = {
+    PropertiesService: {
+      getScriptProperties: () => ({
+        setProperty: (k, v) => { props[k] = v; },
+        getKeys: () => Object.keys(props),
+        getProperty: (k) => props[k]
+      })
+    },
+    FOLDER_NAME_PREFIX: 'StudyQuest_',
+    Drive: {
+      Files: {
+        list: () => ({ items: [{ id: 'id123', title: 'StudyQuest_ABCDEF' }] })
+      }
+    },
+    logError_: () => {},
+  };
+  loadTeacher(context);
+  const result = context.initTeacher('kyoushi');
+  expect(result).toEqual({ status: 'ok', teacherCode: 'ABCDEF' });
+  expect(props['ABCDEF']).toBe('id123');
+});


### PR DESCRIPTION
## Summary
- check My Drive folder search to limit results
- detect existing teacher folder before reading script properties
- test teacher detection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843ffb7ce04832b836aaf7c970e9ba5