### PR TITLE
Fix Drive search queries

### DIFF
--- a/src/Student.gs
+++ b/src/Student.gs
@@ -141,7 +141,7 @@ function initStudent(teacherCode, grade, classroom, number) {
     const teacherFolder = getTeacherRootFolder(teacherCode);
     const studentsRoot  = getOrCreateSubFolder_(teacherFolder, 'Students');
     let stuFolder = getOrCreateSubFolder_(studentsRoot, stuFolderName);
-    const q = `'${stuFolder.getId()}' in parents and name='Responses_${studentId}.csv' and trashed=false`;
+    const q = `'${stuFolder.getId()}' in parents and title='Responses_${studentId}.csv' and trashed=false`;
     const res = Drive.Files.list({ q, maxResults: 1 });
     if (!res.items || res.items.length === 0) {
       try {

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -19,7 +19,7 @@ function generateTeacherCode() {
  * 同名フォルダが複数ある場合、作成日が最新のものを返す
  */
 function findLatestFolderByName_(name) {
-  const q = `'root' in parents and name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+  const q = `'root' in parents and title='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
   try {
     const res = Drive.Files.list({ q, orderBy: 'createdTime desc', maxResults: 1 });
     const items = res.items || [];
@@ -36,7 +36,7 @@ function findLatestFolderByName_(name) {
  * 最も新しいものの教師コードとIDを返す
  */
 function detectTeacherFolderOnDrive_() {
-  const q = `'root' in parents and mimeType='application/vnd.google-apps.folder' and name contains '${FOLDER_NAME_PREFIX}' and trashed=false`;
+  const q = `'root' in parents and mimeType='application/vnd.google-apps.folder' and title contains '${FOLDER_NAME_PREFIX}' and trashed=false`;
   try {
     const res = Drive.Files.list({ q, orderBy: 'createdTime desc' });
     const items = res.items || [];
@@ -225,7 +225,7 @@ function getTeacherRootFolder(teacherCode) {
   }
 
   const name = FOLDER_NAME_PREFIX + teacherCode;
-  const q = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+  const q = `title='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
   let items = [];
   try {
     const res = Drive.Files.list({ q, orderBy: 'createdTime asc' });

--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -27,7 +27,7 @@ function createFolder_(parentId, name) {
  * findSubFolder_(parentId, name): 親フォルダ内で名前一致する最新フォルダを返す
  */
 function findSubFolder_(parentId, name) {
-  const q = `'${parentId}' in parents and name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+  const q = `'${parentId}' in parents and title='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
   try {
     const res = Drive.Files.list({ q, orderBy: 'createdTime desc', maxResults: 1 });
     const items = res.items || [];
@@ -48,7 +48,7 @@ function getOrCreateSubFolder_(parentFolder, name) {
  */
 function overwriteFile_(folder, name, content, mimeType) {
   const folderId = folder.getId();
-  const q = `'${folderId}' in parents and name='${name}' and trashed=false`;
+  const q = `'${folderId}' in parents and title='${name}' and trashed=false`;
   try {
     const res = Drive.Files.list({ q });
     (res.items || []).forEach(f => Drive.Files.trash(f.id));
@@ -64,7 +64,7 @@ function overwriteFile_(folder, name, content, mimeType) {
  */
 function readFileContent_(folder, name) {
   const folderId = folder.getId();
-  const q = `'${folderId}' in parents and name='${name}' and trashed=false`;
+  const q = `'${folderId}' in parents and title='${name}' and trashed=false`;
   try {
     const res = Drive.Files.list({ q, maxResults: 1 });
     const item = (res.items || [])[0];


### PR DESCRIPTION
## Summary
- update Drive query filters to use `title` instead of `name`
- adjust helper functions for new query syntax

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844075a33e0832ba888a9fcc6ba6631