### PR TITLE
Refactor Gemini settings UI

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -72,23 +72,6 @@
         <span id="totalStudents">0</span> 名
       </span>
     </div>
-    <div id="geminiSettings" class="flex flex-col sm:flex-row items-end gap-2">
-      <div>
-        <label for="apiKeySetting" class="text-xs">Gemini APIキー</label>
-        <input id="apiKeySetting" type="password" class="mt-1 p-1 rounded bg-gray-700 focus:outline-none text-sm" placeholder="保存済みの場合は空白" />
-      </div>
-      <div>
-        <label for="personaSetting" class="text-xs">ペルソナ</label>
-        <select id="personaSetting" class="mt-1 p-1 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
-          <option value="">-- 選択 --</option>
-          <option value="小学生向け">小学生向け</option>
-          <option value="中学生向け">中学生向け</option>
-          <option value="教師向け">教師向け</option>
-        </select>
-      </div>
-      <button id="saveGeminiBtn" class="px-3 py-1 bg-pink-600 hover:bg-pink-500 rounded-xl text-sm">保存</button>
-      <span id="geminiStatus" class="text-green-400 text-xs hidden">保存済み</span>
-    </div>
   </header>
   <div id="teacherCodeModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
     <div id="teacherCodeModalText" class="bg-white text-black p-8 rounded-lg text-6xl font-bold text-center tracking-widest"></div>
@@ -98,6 +81,25 @@
        MAIN CONTENT
        ======================================== -->
   <main class="flex-grow p-6 space-y-6 text-base">
+    <section class="bg-gray-800 p-4 rounded-2xl shadow-lg">
+      <div id="geminiSettings" class="flex flex-col sm:flex-row items-end gap-2">
+        <div>
+          <label for="apiKeyInput" class="text-xs">Gemini APIキー</label>
+          <input id="apiKeyInput" type="password" class="mt-1 p-1 rounded bg-gray-700 focus:outline-none text-sm" placeholder="保存済みの場合は空白" />
+        </div>
+        <div>
+          <label for="personaSelect" class="text-xs">ペルソナ</label>
+          <select id="personaSelect" class="mt-1 p-1 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
+            <option value="">-- 選択 --</option>
+            <option value="小学生向け">小学生向け</option>
+            <option value="中学生向け">中学生向け</option>
+            <option value="教師向け">教師向け</option>
+          </select>
+        </div>
+        <button id="saveApiBtn" class="px-3 py-1 bg-pink-600 hover:bg-pink-500 rounded-xl text-sm">保存</button>
+        <span id="apiStatus" class="text-green-400 text-xs hidden"></span>
+      </div>
+    </section>
     <section class="grid md:grid-cols-3 gap-6">
       <!-- ===== 新しい課題フォーム ===== -->
       <div class="md:col-span-1 bg-gray-800 p-4 rounded-2xl shadow-lg">
@@ -254,7 +256,7 @@
       loadGeminiSettings();
       loadClassOptions();
       loadSubjectHistory();
-      document.getElementById('saveGeminiBtn').addEventListener('click', saveGeminiSettings);
+      document.getElementById('saveApiBtn').addEventListener('click', saveGeminiSettings);
       document.getElementById('classSettingBtn').addEventListener('click', () => {
         const cur = prompt('担当クラスを "学年,組;学年,組" の形式で入力してください');
         if (cur === null) return;
@@ -294,7 +296,7 @@
         const subject = document.getElementById('subject').value.trim();
         const q = document.getElementById('question').value.trim();
         const self = document.getElementById('selfEval').checked;
-        const persona = document.getElementById('personaSetting').value;
+        const persona = document.getElementById('personaSelect').value;
         const checkedRadio = document.querySelector('input[name="ansType"]:checked');
         if (!checkedRadio) {
           alert('回答タイプを選択してください。');
@@ -401,7 +403,7 @@
       function loadGeminiSettings() {
         google.script.run
           .withSuccessHandler(data => {
-            const keyInput = document.getElementById('apiKeySetting');
+            const keyInput = document.getElementById('apiKeyInput');
             if (data.apiKey) {
               keyInput.value = '';
               keyInput.placeholder = '********';
@@ -409,8 +411,8 @@
               keyInput.value = '';
               keyInput.placeholder = '';
             }
-            document.getElementById('personaSetting').value = data.persona || '';
-            document.getElementById('geminiStatus').classList.toggle('hidden', !data.apiKey);
+            document.getElementById('personaSelect').value = data.persona || '';
+            document.getElementById('apiStatus').classList.add('hidden');
           })
           .getGeminiSettings(teacherCode);
       }
@@ -436,11 +438,13 @@
 
       // Gemini 設定を保存
       function saveGeminiSettings() {
-        const key = document.getElementById('apiKeySetting').value.trim();
-        const persona = document.getElementById('personaSetting').value;
+        const key = document.getElementById('apiKeyInput').value.trim();
+        const persona = document.getElementById('personaSelect').value;
         google.script.run
           .withSuccessHandler(() => {
-            document.getElementById('geminiStatus').classList.remove('hidden');
+            const status = document.getElementById('apiStatus');
+            status.textContent = '保存しました';
+            status.classList.remove('hidden');
             if (key) {
               alert('設定内容(APIキー・担当クラス)は教師フォルダ内の settings.csv に保存されます。Gemini API は生徒の回答からヒントを生成する目的でのみ利用されます。');
             }


### PR DESCRIPTION
## Summary
- move Gemini API settings from header to new settings section
- rename UI controls to `apiKeyInput`, `personaSelect`, `saveApiBtn`, and `apiStatus`
- style the new section like other cards
- update JS to use new IDs and show status message on save

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684427611384832b9779c8fd155acf74