### PR TITLE
Add class registration modal and card view

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -43,6 +43,16 @@
       cursor: pointer;
       color: #f87171;
     }
+    .class-card {
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      background-color: #374151;
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .class-card.selected {
+      background-color: #4f46e5;
+    }
   </style>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-950 text-gray-200">
@@ -76,11 +86,45 @@
   <div id="teacherCodeModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
     <div id="teacherCodeModalText" class="bg-white text-black p-8 rounded-lg text-6xl font-bold text-center tracking-widest"></div>
   </div>
+  <div id="classModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
+    <div class="bg-gray-800 p-6 rounded-xl space-y-4 w-80 modal-content">
+      <div>
+        <label for="modalGrade" class="block text-sm mb-1">学年</label>
+        <select id="modalGrade" class="w-full p-2 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
+          <option value="">-- 学年 --</option>
+          <option value="1">1年</option>
+          <option value="2">2年</option>
+          <option value="3">3年</option>
+          <option value="4">4年</option>
+          <option value="5">5年</option>
+          <option value="6">6年</option>
+        </select>
+      </div>
+      <div>
+        <label for="modalClass" class="block text-sm mb-1">組</label>
+        <select id="modalClass" class="w-full p-2 rounded bg-gray-700 text-gray-200 focus:outline-none text-sm">
+          <option value="">-- 組 --</option>
+          <option value="1">1組</option>
+          <option value="2">2組</option>
+          <option value="3">3組</option>
+          <option value="4">4組</option>
+        </select>
+      </div>
+      <p id="classPreview" class="text-center text-gray-300"></p>
+      <div class="text-center">
+        <button id="saveClassBtn" class="px-3 py-1 bg-pink-600 hover:bg-pink-500 rounded text-sm">保存</button>
+      </div>
+    </div>
+  </div>
 
   <!-- ========================================
        MAIN CONTENT
        ======================================== -->
   <main class="flex-grow p-6 space-y-6 text-base">
+    <div class="mb-4 flex items-center gap-2">
+      <button id="openClassBtn" class="px-3 py-1 bg-indigo-600 hover:bg-indigo-500 rounded text-sm">クラス登録</button>
+      <div id="currentClassCard" class="flex flex-wrap gap-2"></div>
+    </div>
     <section class="bg-gray-800 p-4 rounded-2xl shadow-lg">
       <div id="geminiSettings" class="flex flex-col sm:flex-row items-end gap-2">
         <div>
@@ -215,6 +259,7 @@
 
     // デバッグログ出力用
     let debugContentElem;
+    let classList = [];
     function debug(msg) {
       if (!debugContentElem) return;
       const t = new Date().toLocaleTimeString();
@@ -257,14 +302,8 @@
       loadClassOptions();
       loadSubjectHistory();
       document.getElementById('saveApiBtn').addEventListener('click', saveGeminiSettings);
-      document.getElementById('classSettingBtn').addEventListener('click', () => {
-        const cur = prompt('担当クラスを "学年,組;学年,組" の形式で入力してください');
-        if (cur === null) return;
-        google.script.run
-          .withSuccessHandler(loadClassOptions)
-          .withFailureHandler(err => alert('更新に失敗: ' + err.message))
-          .setClassIdMap(teacherCode, cur);
-      });
+      document.getElementById('classSettingBtn').addEventListener('click', openClassModal);
+      document.getElementById('openClassBtn').addEventListener('click', openClassModal);
 
       // 3) 回答タイプ選択時に optionsArea を表示／非表示
       Array.from(document.getElementsByName('ansType')).forEach(radio => {
@@ -419,20 +458,23 @@
 
       function loadClassOptions() {
         google.script.run.withSuccessHandler(map => {
+          classList = Object.keys(map).map(id => map[id].split('-'));
           const area = document.getElementById('taskClassButtons');
-          if (!area) return;
-          area.innerHTML = '';
-          Object.keys(map).forEach(id => {
-            const label = document.createElement('label');
-            label.className = 'flex items-center gap-1 px-2 py-1 bg-gray-700 rounded text-sm cursor-pointer';
-            const input = document.createElement('input');
-            input.type = 'radio';
-            input.name = 'taskClassRadio';
-            input.value = id;
-            label.appendChild(input);
-            label.appendChild(document.createTextNode(map[id]));
-            area.appendChild(label);
-          });
+          if (area) {
+            area.innerHTML = '';
+            Object.keys(map).forEach(id => {
+              const label = document.createElement('label');
+              label.className = 'flex items-center gap-1 px-2 py-1 bg-gray-700 rounded text-sm cursor-pointer';
+              const input = document.createElement('input');
+              input.type = 'radio';
+              input.name = 'taskClassRadio';
+              input.value = id;
+              label.appendChild(input);
+              label.appendChild(document.createTextNode(map[id]));
+              area.appendChild(label);
+            });
+          }
+          renderClassCards(map);
         }).getClassIdMap_(teacherCode);
       }
 
@@ -580,6 +622,73 @@
           case 'checkbox': return 'チェックボックス';
           default:         return '不明';
         }
+      }
+
+      function openClassModal() {
+        const modal = document.getElementById('classModal');
+        document.getElementById('modalGrade').value = '';
+        document.getElementById('modalClass').value = '';
+        document.getElementById('classPreview').textContent = '';
+        modal.classList.remove('hidden');
+        gsap.fromTo(modal, { opacity: 0 }, { opacity: 1, duration: 0.2 });
+        gsap.fromTo(modal.querySelector('.modal-content'), { scale: 0.8, opacity: 0 }, { scale: 1, opacity: 1, duration: 0.3 });
+      }
+
+      function closeClassModal() {
+        const modal = document.getElementById('classModal');
+        gsap.to(modal, { opacity: 0, duration: 0.2, onComplete: () => modal.classList.add('hidden') });
+      }
+
+      document.getElementById('classModal').addEventListener('click', e => {
+        if (e.target.id === 'classModal') closeClassModal();
+      });
+
+      document.getElementById('modalGrade').addEventListener('change', updatePreview);
+      document.getElementById('modalClass').addEventListener('change', updatePreview);
+
+      function updatePreview() {
+        const g = document.getElementById('modalGrade').value;
+        const c = document.getElementById('modalClass').value;
+        const preview = document.getElementById('classPreview');
+        preview.textContent = g && c ? `${g}-${c}` : '';
+      }
+
+      document.getElementById('saveClassBtn').addEventListener('click', () => {
+        const g = document.getElementById('modalGrade').value;
+        const c = document.getElementById('modalClass').value;
+        if (!g || !c) {
+          alert('学年と組を選択してください。');
+          return;
+        }
+        classList.push([g, c]);
+        const idsString = classList.map(x => x.join(',')).join(';');
+        google.script.run
+          .withSuccessHandler(map => {
+            loadClassOptions();
+            closeClassModal();
+          })
+          .withFailureHandler(err => alert('更新に失敗: ' + err.message))
+          .setClassIdMap(teacherCode, idsString);
+      });
+
+      function renderClassCards(map) {
+        const cont = document.getElementById('currentClassCard');
+        if (!cont) return;
+        cont.innerHTML = '';
+        Object.keys(map).forEach(id => {
+          const card = document.createElement('div');
+          card.className = 'class-card';
+          card.textContent = map[id];
+          card.dataset.id = id;
+          card.addEventListener('click', () => {
+            document.querySelectorAll('#currentClassCard .class-card').forEach(c => c.classList.remove('selected'));
+            card.classList.add('selected');
+            const radio = document.querySelector(`#taskClassButtons input[value="${id}"]`);
+            if (radio) radio.checked = true;
+            gsap.fromTo(card, { scale: 0.9 }, { scale: 1, duration: 0.4, ease: 'bounce.out' });
+          });
+          cont.appendChild(card);
+        });
       }
 
 


### PR DESCRIPTION
## Summary
- add modal UI for registering classes
- show class cards at top of manage page
- switch to modal flow for class setting

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684428477b14832bb1b1637bb85943ab