### PR TITLE
Centralize escapeHtml utility in HTML files

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -57,12 +57,14 @@
 
   <script>
     function escapeHtml(text) {
-      return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      };
+      return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
     }
 
     // デバッグログ出力用
@@ -83,10 +85,6 @@
       document.getElementById('versionInfo').addEventListener('click', () => {
         debugPanel.classList.remove('hidden');
       });
-      function escapeHtml(text) {
-        const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
-        return text == null ? '' : text.replace(/[&<>"']/g, m => map[m]);
-      }
 
       const params = new URLSearchParams(location.search);
       const teacherCode = params.get('teacher');
@@ -95,10 +93,6 @@
       debug('🔄 ページ読み込み完了');
       debug(`▶ teacherCode="${teacherCode}", taskId="${taskId || ''}"`);
 
-      function escapeHtml(text) {
-        const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
-        return String(text).replace(/[&<>"']/g, m => map[m]);
-      }
       if (!teacherCode) {
         alert('不正なアクセスです。');
         location.href = '?page=login';

--- a/src/input.html
+++ b/src/input.html
@@ -152,12 +152,14 @@
 
   <script>
     function escapeHtml(text) {
-      return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      };
+      return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
     }
 
     // Lucide Icons のレンダリング
@@ -179,14 +181,6 @@
       debugContentElem.scrollTop = debugContentElem.scrollHeight;
     }
 
-    function escapeHtml(text) {
-      return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-    }
 
     // デバッグパネル閉じるボタン
     const debugPanel = document.getElementById('debugPanel');
@@ -208,10 +202,6 @@
     let allAnswered   = [];
     let currentQuest  = null;
 
-    function escapeHtml(text) {
-      const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
-      return text == null ? '' : text.replace(/[&<>"']/g, m => map[m]);
-    }
 
     document.addEventListener('DOMContentLoaded', () => {
       // 背景パーティクルを起動


### PR DESCRIPTION
## Summary
- remove duplicate `escapeHtml` definitions
- keep one shared `escapeHtml` at top of each HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68442bdfa230832bb4eff4ac0f3e9440