### PR TITLE
Fix Gemini settings alignment

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -126,7 +126,7 @@
       <div id="currentClassCard" class="flex flex-wrap gap-2"></div>
     </div>
     <section class="bg-gray-800 p-4 rounded-2xl shadow-2xl">
-      <div id="geminiSettings" class="flex flex-col sm:flex-row items-end gap-2">
+      <div id="geminiSettings" class="flex flex-col sm:flex-row items-start gap-2">
         <div>
           <label for="apiKeyInput" class="text-xs">Gemini APIキー</label>
           <input id="apiKeyInput" type="password" class="mt-1 p-1 rounded bg-gray-700 focus:outline-none focus:ring-2 focus:ring-pink-400 text-sm" placeholder="保存済みの場合は空白" />


### PR DESCRIPTION
## Summary
- align Gemini API settings inputs to the left

## Testing
- `scripts/setup-codex.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684435194378832bb9f00350a62b4256