### PR TITLE
Remove unused class setting button

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -152,7 +152,6 @@
           新しい課題
         </h2>
         <form id="taskForm" class="space-y-4 text-base">
-          <button id="classSettingBtn" type="button" class="px-2 py-1 bg-indigo-600 hover:bg-indigo-500 rounded-2xl shadow-2xl text-sm">クラス設定</button>
           <!-- ■ 担当クラス -->
           <div>
             <label for="taskClass" class="text-sm">■ 担当クラス</label>
@@ -302,7 +301,6 @@
       loadClassOptions();
       loadSubjectHistory();
       document.getElementById('saveApiBtn').addEventListener('click', saveGeminiSettings);
-      document.getElementById('classSettingBtn').addEventListener('click', openClassModal);
       document.getElementById('openClassBtn').addEventListener('click', openClassModal);
 
       // 3) 回答タイプ選択時に optionsArea を表示／非表示


### PR DESCRIPTION
## Summary
- delete the class-setting button from the manage page
- drop the event listener referencing the removed button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684437901ac0832ba18f30e01462e07c