### PR TITLE
Update login page modal and loading position

### DIFF
--- a/src/login.html
+++ b/src/login.html
@@ -113,6 +113,16 @@
       cursor: pointer;
       color: #f87171;
     }
+    #loginBox {
+      position: relative;
+    }
+    #loading {
+      position: absolute;
+      bottom: 1rem;
+      left: 0;
+      width: 100%;
+      text-align: center;
+    }
   </style>
 </head>
 <body class="text-gray-200 bg-gradient-to-br from-purple-800 to-indigo-700">
@@ -157,26 +167,20 @@
           <i data-lucide="log-in" class="w-5 h-5"></i>
           <span>ログイン</span>
         </button>
-        <p id="loading" class="mt-3 text-xs text-gray-400 hidden">通信中…</p>
       </form>
+      <p id="loading" class="mt-3 text-xs text-gray-400 hidden">通信中…</p>
     </section>
   </main>
 
-  <div id="firstMessage" class="fixed inset-0 bg-black/60 items-center justify-center p-4 hidden">
-    <div class="glass-panel rounded-2xl p-8 w-full max-w-lg text-center shadow-2xl">
-      <i data-lucide="party-popper" class="w-12 h-12 text-amber-400 mx-auto mb-4"></i>
-      <h2 class="text-2xl font-bold mb-2">ようこそ！</h2>
-      <p class="text-gray-300 mb-4">
-        Google DriveにStudyQuest用のフォルダを作成します。<br>
-        生徒には以下の招待コードを伝えてください。
-      </p>
-      <div class="bg-gray-900/50 p-4 rounded-lg text-center my-4">
-        <p class="text-sm text-gray-400">あなたの招待コード</p>
-        <p class="text-3xl font-bold tracking-widest text-amber-300">AB12-CD34</p>
-      </div>
-      <button id="closeFirstMsg" class="w-full game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 active:border-indigo-700">
-        始める
-      </button>
+  <!-- 初回ログイン用注意メッセージ（モーダル）-->
+  <div id="firstMessage" class="fixed inset-0 bg-black/60 flex items-center justify-center p-4 hidden">
+    <div class="glass-panel modal rounded-2xl p-8 w-full max-w-md text-center shadow-2xl">
+      <p class="mb-2">🎉 初回ログインありがとうございます！</p>
+      <p class="mb-2">これから Google Drive 上に</p>
+      <p class="mb-2"><strong>「StudyQuest_<span id="newCodeSpan"></span>」</strong>フォルダを作成します。</p>
+      <p class="mb-4">児童の皆さんには「教師コード（<span id="newCodeSpan2"></span>）」をお伝えください。</p>
+      <p class="text-xs text-gray-300 mb-4">※既に同名フォルダがある場合は上書きされますのでご注意を。</p>
+      <button id="closeFirstMsg" class="game-btn bg-indigo-600 text-white p-3 rounded-2xl font-bold border-indigo-800 hover:bg-indigo-500 active:border-indigo-700 w-full shadow-2xl">了解しました</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- refine login modal text for first-time login
- move communication message outside login form and style absolute positioning

## Testing
- `npm test` *(fails: parseSettingsCsv_ is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844569d4830832ba2b7d62b97ab517f