### PR TITLE
Integrate class data into StudyQuest_DB

### DIFF
--- a/src/Student.gs
+++ b/src/Student.gs
@@ -168,11 +168,17 @@ function initStudent(teacherCode, grade, classroom, number) {
     if (taskSheet) {
       const lastRow = taskSheet.getLastRow();
       if (lastRow >= 2) {
-        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 5).getValues();
+        const map = getClassIdMap(teacherCode);
+        let classId = null;
+        Object.keys(map).forEach(id => {
+          if (map[id] === `${grade}-${classroom}`) classId = id;
+        });
+        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 6).getValues();
         taskData.forEach(row => {
+          if (classId && String(row[1]) !== String(classId)) return;
           const taskId        = row[0];
-          const payloadAsJson = row[1];
-          const createdAt     = row[3]; // 作成日時
+          const payloadAsJson = row[2];
+          const createdAt     = row[4]; // 作成日時
           let questionText    = '';
           try {
             const parsed = JSON.parse(payloadAsJson);
@@ -187,4 +193,15 @@ function initStudent(teacherCode, grade, classroom, number) {
   }
 
   return { status: 'ok' };
+}
+
+function getStudentHistory(teacherCode, studentId) {
+  studentId = String(studentId || '').trim();
+  const ss = getSpreadsheetByTeacherCode(teacherCode);
+  if (!ss) return [];
+  const sheet = findStudentSheet_(ss, studentId);
+  if (!sheet) return [];
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return [];
+  return sheet.getRange(2, 1, lastRow - 1, 9).getValues();
 }

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -107,7 +107,7 @@ function initTeacher(passcode) {
     {
       name: SHEET_TASKS,
       color: "ff9900",
-      header: ['ID', '問題データ(JSON)', '自己評価許可', '作成日時', 'ペルソナ'],
+      header: ['ID', 'ClassID', '問題データ(JSON)', '自己評価許可', '作成日時', 'ペルソナ'],
       description: "作成された課題の一覧です。"
     },
     {

--- a/src/input.html
+++ b/src/input.html
@@ -154,7 +154,7 @@ function loadTasks() {
       history = Array.isArray(history) ? history : [];
       renderLists(tasks || [], history);
     }).getStudentHistory(teacherCode, studentId);
-  }).listTasks(teacherCode);
+  }).listTasksForClass(teacherCode, grade, classroom);
 }
 
 function renderLists(tasks, history) {


### PR DESCRIPTION
## Summary
- store class info in `Tasks` sheet
- filter imported tasks by class when a student logs in
- expose student history API and class-based task listing
- adjust HTML to call new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445fe75e68832bba8d518cb4f7ffee