### PR TITLE
Add global Gemini API key retrieval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "studyquest",
-  "version": "1.0.12",
+  "version": "1.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studyquest",
-      "version": "1.0.12",
+      "version": "1.0.53",
       "devDependencies": {
         "@google/clasp": "^2.4.2",
         "jest": "^29.7.0"

--- a/src/Gemini.gs
+++ b/src/Gemini.gs
@@ -6,8 +6,7 @@ function callGeminiAPI_GAS(teacherCode, prompt, persona) {
   };
   const base = personaMap[persona] || '';
   const finalPrompt = base + '\n' + prompt;
-  const settings = getGeminiSettings(teacherCode);
-  const apiKey = settings.apiKey;
+  const apiKey = getGlobalGeminiApiKey();
   if (!apiKey) return 'APIキーが設定されていません';
   const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' + apiKey;
   const payload = { contents: [{ parts: [{ text: finalPrompt }] }] };

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -341,3 +341,14 @@ function getGeminiSettings(teacherCode) {
   const data = loadTeacherSettings_(teacherCode);
   return { apiKey: data.apiKey || '', persona: data.persona || '' };
 }
+
+/**
+ * getGlobalGeminiApiKey(): スクリプト全体で使用する Gemini API キーを取得
+ */
+function getGlobalGeminiApiKey() {
+  const props = PropertiesService.getScriptProperties();
+  const encoded = props.getProperty('globalGeminiApiKey') || '';
+  return encoded
+    ? Utilities.newBlob(Utilities.base64Decode(encoded)).getDataAsString()
+    : '';
+}


### PR DESCRIPTION
## Summary
- introduce `getGlobalGeminiApiKey`
- call the new function in `callGeminiAPI_GAS`
- sync `package-lock.json` version with package.json

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446f98735c832b8564cf4a6422f59f