### PR TITLE
Use global Gemini API key

### DIFF
--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -158,7 +158,7 @@ function initTeacher(passcode) {
   tocSheet.autoResizeColumn(2);
 
   props.setProperty(newCode, folderInstance.getId());
-  saveTeacherSettings_(newCode, { apiKey: '', persona: '', classes: [] });
+  saveTeacherSettings_(newCode, { persona: '', classes: [] });
   return {
     status: 'new',
     teacherCode: newCode,
@@ -198,11 +198,6 @@ function ensureSettingsSheet_(ss) {
 }
 
 function saveTeacherSettings_(teacherCode, obj) {
-  const props = PropertiesService.getScriptProperties();
-  if (obj.apiKey !== undefined) {
-    const encoded = Utilities.base64Encode(obj.apiKey || '');
-    props.setProperty(`${teacherCode}_apiKey`, encoded);
-  }
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) return;
   const sheet = ensureSettingsSheet_(ss);
@@ -215,11 +210,8 @@ function saveTeacherSettings_(teacherCode, obj) {
 }
 
 function loadTeacherSettings_(teacherCode) {
-  const props = PropertiesService.getScriptProperties();
-  const encoded = props.getProperty(`${teacherCode}_apiKey`) || '';
-  const apiKey = encoded ? Utilities.newBlob(Utilities.base64Decode(encoded)).getDataAsString() : '';
   const ss = getSpreadsheetByTeacherCode(teacherCode);
-  const data = { apiKey, persona: '', classes: [] };
+  const data = { persona: '', classes: [] };
   if (ss) {
     const sheet = ss.getSheetByName(SHEET_SETTINGS);
     if (sheet) {
@@ -328,8 +320,8 @@ function getClassIdMap(teacherCode) {
 }
 
 function setGeminiSettings(teacherCode, apiKey, persona) {
+  if (apiKey !== undefined) setGlobalGeminiApiKey(apiKey);
   const data = loadTeacherSettings_(teacherCode);
-  if (apiKey !== undefined) data.apiKey = apiKey;
   if (persona !== undefined) data.persona = persona;
   saveTeacherSettings_(teacherCode, data);
 }
@@ -339,5 +331,17 @@ function setGeminiSettings(teacherCode, apiKey, persona) {
  */
 function getGeminiSettings(teacherCode) {
   const data = loadTeacherSettings_(teacherCode);
-  return { apiKey: data.apiKey || '', persona: data.persona || '' };
+  return { apiKey: getGlobalGeminiApiKey(), persona: data.persona || '' };
+}
+
+function setGlobalGeminiApiKey(apiKey) {
+  const props = PropertiesService.getScriptProperties();
+  const encoded = Utilities.base64Encode(apiKey || '');
+  props.setProperty('geminiApiKey', encoded);
+}
+
+function getGlobalGeminiApiKey() {
+  const props = PropertiesService.getScriptProperties();
+  const encoded = props.getProperty('geminiApiKey') || '';
+  return encoded ? Utilities.newBlob(Utilities.base64Decode(encoded)).getDataAsString() : '';
 }

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -74,7 +74,7 @@ test('initTeacher creates StudyQuest_DB when none exists', () => {
   expect(context.SpreadsheetApp.create).toHaveBeenCalledWith('StudyQuest_DB');
 });
 
-test('saveTeacherSettings persists values correctly', () => {
+test('saveTeacherSettings persists values correctly and global key handling', () => {
   const props = {};
   const sheetData = [['type', 'value1', 'value2']];
   const sheetStub = {
@@ -103,12 +103,17 @@ test('saveTeacherSettings persists values correctly', () => {
   };
   loadTeacher(context);
   context.getSpreadsheetByTeacherCode = () => ssStub;
-  context.saveTeacherSettings_('ABC', { apiKey: 'xyz', persona: 'P1', classes: [[1, 'A']] });
-  expect(props['ABC_apiKey']).toBe(Buffer.from('xyz').toString('base64'));
+  context.saveTeacherSettings_('ABC', { persona: 'P1', classes: [[1, 'A']] });
+  expect(props['ABC_apiKey']).toBeUndefined();
   const loaded = context.loadTeacherSettings_('ABC');
-  expect(loaded.apiKey).toBe('xyz');
   expect(loaded.persona).toBe('P1');
   expect(loaded.classes).toEqual([[1, 'A']]);
+  // test global key functions
+  context.setGeminiSettings('ABC', 'xyz', 'P2');
+  expect(props['geminiApiKey']).toBe(Buffer.from('xyz').toString('base64'));
+  const settings = context.getGeminiSettings('ABC');
+  expect(settings.apiKey).toBe('xyz');
+  expect(settings.persona).toBe('P2');
   expect(sheetStub.appendRow).toHaveBeenCalledWith(['persona', 'P1', '']);
   expect(sheetStub.appendRow).toHaveBeenCalledWith(['class', 1, 'A']);
 });


### PR DESCRIPTION
## Summary
- manage Gemini API key via new global helper functions
- adjust teacher settings logic to only store persona per teacher
- update unit tests for new API key handling

## Testing
- `./scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446fa969f4832ba894f962b9d7eb47