### PR TITLE
Add migration script for shared Gemini API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,26 @@ StudyQuest_<TeacherCode>/
 -   **データ操作**: すべてのデータは `SpreadsheetApp` サービスを通じて `StudyQuest_DB` スプレッドシートに直接読み書きします。
 -   **データ集計**: `QUERY`などのスプレッドシート関数を最大限に活用し、GAS側での複雑なデータ処理を避けます。
 -   **フロントエンド構造**: `include()` を活用し、UIパーツ（ヘッダー、フッターなど）を共通化します。
+
+## 8. Gemini API キーの共有管理
+
+Gemini API キーは教師全体で 1 つを共有し、Apps Script のスクリプトプロパティ
+`geminiApiKey` として Base64 形式で保存されます。設定画面から入力したキーは
+`setGlobalGeminiApiKey` により保存され、`getGlobalGeminiApiKey` で取得できます。
+
+`Settings` シートの列構成 (`type`, `value1`, `value2`) は変更せず、保存される
+エントリは `persona` と `class` のみです。過去バージョンで使用されていた
+`\${teacherCode}_apiKey` プロパティは不要になったため、以下のスクリプトを一度
+実行して削除してください。
+
+```javascript
+// 移行用: 旧キーを削除
+function deleteLegacyApiKeys() {
+  const props = PropertiesService.getScriptProperties();
+  (props.getKeys() || []).forEach(k => {
+    if (/_apiKey$/.test(k) && k !== 'geminiApiKey') {
+      props.deleteProperty(k);
+    }
+  });
+}
+```

--- a/src/Migration.gs
+++ b/src/Migration.gs
@@ -1,0 +1,13 @@
+/**
+ * deleteLegacyApiKeys:
+ * `${teacherCode}_apiKey` 形式の旧スクリプトプロパティを削除します。
+ */
+function deleteLegacyApiKeys() {
+  const props = PropertiesService.getScriptProperties();
+  const keys = props.getKeys() || [];
+  keys.forEach(k => {
+    if (/\_apiKey$/.test(k) && k !== 'geminiApiKey') {
+      props.deleteProperty(k);
+    }
+  });
+}

--- a/tests/Migration.test.js
+++ b/tests/Migration.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadMigration(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Migration.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('deleteLegacyApiKeys removes *_apiKey properties', () => {
+  const props = { 'ABC_apiKey': '123', geminiApiKey: 'xyz' };
+  const context = {
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getKeys: () => Object.keys(props),
+        deleteProperty: k => { delete props[k]; }
+      })
+    }
+  };
+  loadMigration(context);
+  context.deleteLegacyApiKeys();
+  expect(props).toEqual({ geminiApiKey: 'xyz' });
+});

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -116,4 +116,5 @@ test('saveTeacherSettings persists values correctly and global key handling', ()
   expect(settings.persona).toBe('P2');
   expect(sheetStub.appendRow).toHaveBeenCalledWith(['persona', 'P1', '']);
   expect(sheetStub.appendRow).toHaveBeenCalledWith(['class', 1, 'A']);
+  expect(sheetData[0]).toEqual(['type', 'value1', 'value2']);
 });


### PR DESCRIPTION
## Summary
- add migration helper `deleteLegacyApiKeys`
- document shared Gemini API key storage and migration
- verify settings sheet header in tests
- test migration helper

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844727c20dc832bbd13f9b665b40fd7