### PR TITLE
Add shared escapeHtml utility

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -93,16 +93,7 @@
   </div>
 
   <script>
-    function escapeHtml(text) {
-      const map = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;'
-      };
-      return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
-    }
+<?!= include('shared/escapeHtml.js'); ?>
 
     const canvas = document.getElementById('particleCanvas');
     const ctx = canvas.getContext('2d');

--- a/src/input.html
+++ b/src/input.html
@@ -102,6 +102,7 @@
     </main>
   </div>
 <script>
+<?!= include('shared/escapeHtml.js'); ?>
 const SCRIPT_URL = '<?!= scriptUrl.replace("/dev","/exec") ?>';
 const teacherCode = '<?!= teacher ?>';
 const grade = '<?!= grade ?>';
@@ -220,12 +221,14 @@ function renderInput(q, attempt) {
   } else if (q.type === 'radio') {
     q.choices.forEach((c, i) => {
       const id = `r${i}`;
-      area.innerHTML += `<label class="flex items-center gap-1"><input type="radio" name="choice" value="${c}" id="${id}">${c}</label>`;
+      const opt = escapeHtml(c);
+      area.innerHTML += `<label class="flex items-center gap-1"><input type="radio" name="choice" value="${opt}" id="${id}">${opt}</label>`;
     });
   } else if (q.type === 'checkbox') {
     q.choices.forEach((c, i) => {
       const id = `c${i}`;
-      area.innerHTML += `<label class="flex items-center gap-1"><input type="checkbox" value="${c}" class="cb">${c}</label>`;
+      const opt = escapeHtml(c);
+      area.innerHTML += `<label class="flex items-center gap-1"><input type="checkbox" value="${opt}" class="cb">${opt}</label>`;
     });
   }
 }
@@ -309,9 +312,6 @@ function appendMsg(type, text) {
   log.scrollTop = log.scrollHeight;
 }
 
-function escapeHtml(str) {
-  return str == null ? '' : String(str).replace(/[&<>'"]/g, m => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[m]));
-}
 
 function loadXp() { updateXpBar(); }
 function updateXpBar() {

--- a/src/manage.html
+++ b/src/manage.html
@@ -291,6 +291,7 @@
 <script src="https://cdn.jsdelivr.net/npm/lucide@0.259.0/dist/umd/lucide.min.js"></script>
 
   <script>
+<?!= include('shared/escapeHtml.js'); ?>
     // Lucide Icons を SVG に置き換える
     function renderIcons(scope) {
       if (window.lucide && typeof window.lucide.createIcons === 'function') {
@@ -676,10 +677,6 @@
         });
       }
 
-      function escapeHtml(text) {
-        const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
-        return text ? text.replace(/[&<>"']/g, m => map[m]) : '';
-      }
 
       // 9) フォームリセットヘルパー
       function resetForm() {
@@ -746,12 +743,12 @@
           try {
             data = JSON.parse(x.q);
             detailHtml = `
-              <p class="text-sm text-indigo-300 mb-1">【${data.subject || '—'}】</p>
-              <p class="text-base mb-1 whitespace-pre-wrap">${data.question || ''}</p>
+              <p class="text-sm text-indigo-300 mb-1">【${escapeHtml(data.subject || '—')}】</p>
+              <p class="text-base mb-1 whitespace-pre-wrap">${escapeHtml(data.question || '')}</p>
               <p class="text-sm text-gray-400">回答タイプ: ${renderTypeLabel(data.type)}</p>
             `;
           } catch (_) {
-            detailHtml = `<p class="text-base mb-1 whitespace-pre-wrap">${x.q}</p>`;
+            detailHtml = `<p class="text-base mb-1 whitespace-pre-wrap">${escapeHtml(x.q)}</p>`;
           }
 
           const card = document.createElement('div');

--- a/src/shared/escapeHtml.js
+++ b/src/shared/escapeHtml.js
@@ -1,0 +1,14 @@
+/**
+ * escapeHtml(text): Escape special HTML characters
+ * @param {string} text
+ * @return {string}
+ */
+function escapeHtml(text) {
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
+}
+
+// Export for tests or Node usage
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = escapeHtml;
+}


### PR DESCRIPTION
## Summary
- add `src/shared/escapeHtml.js`
- import the shared escapeHtml function in board, manage and input pages
- sanitize option rendering with escapeHtml

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684475cb7368832b813ecc9e42ef9555