### PR TITLE
Fix quest button layout

### DIFF
--- a/src/quest.html
+++ b/src/quest.html
@@ -81,12 +81,12 @@
           <div id="chatLog" class="flex-1 p-4 space-y-4 overflow-y-auto"></div>
           <div id="inputArea" class="bg-gray-900/70 p-4 border-t-2 border-gray-700">
             <div id="answerInputs" class="mb-3"></div>
-            <div class="flex items-center gap-3">
-              <button id="sendBtn" class="game-btn bg-pink-600 text-white px-6 py-2 rounded-lg font-bold border-pink-800 hover:bg-pink-500 flex items-center gap-2">
+            <div class="flex items-center justify-between gap-3">
+              <button id="sendBtn" class="game-btn bg-pink-600 text-white px-6 py-2 rounded-lg font-bold border-pink-800 hover:bg-pink-500 flex items-center gap-2 flex-1">
                 <i data-lucide="send-horizontal"></i>
                 <span>回答する</span>
               </button>
-              <a id="viewAnswersBtn" class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-500 flex items-center gap-2" href="#" target="_blank">
+              <a id="viewAnswersBtn" class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-500 flex items-center gap-2 flex-1" href="#" target="_blank">
                 <i data-lucide="users"></i>
                 <span>みんなの回答を見る</span>
               </a>


### PR DESCRIPTION
## Summary
- make `sendBtn` and `viewAnswersBtn` use flex-1 so they fill the line
- space buttons across the width using `justify-between`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684492de6e68832bb0cccf72b75497af