### PR TITLE
Replace GeminiApiKey usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ StudyQuest_<TeacherCode>/
 
 Gemini API キーは教師全体で 1 つを共有し、Apps Script のスクリプトプロパティ
 `geminiApiKey` として Base64 形式で保存されます。設定画面から入力したキーは
-`setGlobalGeminiApiKey` により保存され、`getGlobalGeminiApiKey` で取得できます。
+`setGlobalGeminiApiKey` により保存され、`getGlobalGeminiApiKey` で取得できます。スクリプトプロパティの名前は **geminiApiKey** 固定です。
 
 `Settings` シートの列構成 (`type`, `value1`, `value2`) は変更せず、保存される
 エントリは `persona` と `class` のみです。過去バージョンで使用されていた

--- a/src/Gemini.gs
+++ b/src/Gemini.gs
@@ -6,7 +6,7 @@ function callGeminiAPI_GAS(teacherCode, prompt, persona) {
   };
   const base = personaMap[persona] || '';
   const finalPrompt = base + '\n' + prompt;
-  const apiKey = GeminiApiKey();
+  const apiKey = getGlobalGeminiApiKey();
   if (!apiKey) return 'APIキーが設定されていません';
   const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' + apiKey;
   const payload = { contents: [{ parts: [{ text: finalPrompt }] }] };

--- a/tests/Gemini.test.js
+++ b/tests/Gemini.test.js
@@ -7,6 +7,11 @@ function loadGemini(context) {
   vm.runInNewContext(code, context);
 }
 
+function loadTeacher(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Teacher.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
 test('generateFollowupFromAnswer builds prompt and calls API', () => {
   const calls = [];
   const context = {};
@@ -20,4 +25,27 @@ test('generateFollowupFromAnswer builds prompt and calls API', () => {
   expect(calls[0].t).toBe('T1');
   expect(calls[0].persona).toBe('P');
   expect(calls[0].p).toContain('sample answer');
+});
+
+test('callGeminiAPI_GAS uses getGlobalGeminiApiKey', () => {
+  const context = {
+    UrlFetchApp: {
+      fetch: jest.fn(() => ({ getContentText: () => JSON.stringify({}) }))
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({ getProperty: jest.fn(() => 'ZGF0YQ==') })
+    },
+    Utilities: {
+      base64Decode: str => Buffer.from(str, 'base64'),
+      newBlob: data => ({ getDataAsString: () => data.toString() }),
+      base64Encode: str => Buffer.from(str).toString('base64')
+    }
+  };
+  loadTeacher(context);
+  loadGemini(context);
+  const spy = jest.fn(() => 'TESTKEY');
+  context.getGlobalGeminiApiKey = spy;
+  context.callGeminiAPI_GAS('TC', 'prompt', '');
+  expect(spy).toHaveBeenCalled();
+  expect(context.UrlFetchApp.fetch.mock.calls[0][0]).toContain('key=TESTKEY');
 });


### PR DESCRIPTION
## Summary
- use `getGlobalGeminiApiKey()` inside `callGeminiAPI_GAS`
- add a unit test for API key retrieval logic
- clarify script property name in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844969f3b98832b9a9844fb15c3d867