### PR TITLE
Add close button in manage cards

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -818,11 +818,11 @@
             ${detailHtml}
             <div class="flex justify-between items-center mt-2 pr-8">
               <p class="text-sm text-gray-400">${x.date}</p>
-              <button class="closeBtn p-1" data-id="${x.id}" title="このクエストを閉じる">
-                <i data-icon="SquareX" class="w-5 h-5 text-red-300"></i>
-              </button>
             </div>
             <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2">
+              <button class="closeBtn p-1" data-id="${x.id}" title="このクエストを閉じる">
+                <i data-icon="SquareX" class="w-6 h-6 text-red-300"></i>
+              </button>
               <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
                 <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
               </button>


### PR DESCRIPTION
## Summary
- insert `closeBtn` into cards rendered by `renderTasks()`
- ensure list refreshes after close via existing `loadTasks()` call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68449fcabba4832b9d4df5f0552c4b23