### PR TITLE
Implement draft task support

### DIFF
--- a/src/Migration.gs
+++ b/src/Migration.gs
@@ -11,3 +11,20 @@ function deleteLegacyApiKeys() {
     }
   });
 }
+
+/**
+ * addDraftColumn(teacherCode):
+ * 課題シートに draft 列が無ければ追加
+ */
+function addDraftColumn(teacherCode) {
+  const ss = getSpreadsheetByTeacherCode(teacherCode);
+  if (!ss) return false;
+  const sheet = ss.getSheetByName(SHEET_TASKS);
+  if (!sheet) return false;
+  const lastCol = sheet.getLastColumn();
+  const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  if (headers.includes('draft')) return true;
+  sheet.insertColumnAfter(Math.max(7, lastCol));
+  sheet.getRange(1, Math.max(8, lastCol + 1)).setValue('draft');
+  return true;
+}

--- a/src/Student.gs
+++ b/src/Student.gs
@@ -142,9 +142,10 @@ function initStudent(teacherCode, grade, classroom, number) {
   if (subsSheet && tasksSheet) {
     const last = tasksSheet.getLastRow();
     if (last >= 2) {
-      const rows = tasksSheet.getRange(2, 1, last - 1, 7).getValues();
+      const rows = tasksSheet.getRange(2, 1, last - 1, 8).getValues();
       rows.forEach(r => {
         if (String(r[6] || '').toLowerCase() === 'closed') return;
+        if (String(r[7] || '') === '1') return;
         const taskId = r[0];
         const createdAt = r[3];
         subsSheet.appendRow([createdAt, studentId, taskId, '', 0, 0, 0, '', 0, 0]);
@@ -174,9 +175,10 @@ function initStudent(teacherCode, grade, classroom, number) {
         Object.keys(map).forEach(id => {
           if (map[id] === `${grade}-${classroom}`) classId = id;
         });
-        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 7).getValues();
+        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 8).getValues();
         taskData.forEach(row => {
           if (String(row[6] || '').toLowerCase() === 'closed') return;
+          if (String(row[7] || '') === '1') return;
           if (classId && String(row[1]) !== String(classId)) return;
           const taskId        = row[0];
           const payloadAsJson = row[2];

--- a/src/manage.html
+++ b/src/manage.html
@@ -265,6 +265,10 @@
                             <i data-lucide="wand-sparkles" class="w-5 h-5"></i>
                             <span>クエストを作成する</span>
                         </button>
+                        <button type="button" id="deleteDraftBtn" class="w-full game-btn bg-gray-600 text-white px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-500 text-base mt-2 flex items-center justify-center gap-2">
+                            <i data-lucide="trash-2" class="w-5 h-5"></i>
+                            <span>下書きを削除</span>
+                        </button>
                     </form>
                 </section>
 
@@ -331,6 +335,7 @@
 
       let aiCredits = 3;
       let generationHistory = [];
+      let draftTaskId = null;
       updateAiCreditDisplay();
 
       // 2) 右上バッジをセット
@@ -353,6 +358,19 @@
       document.getElementById('personaInput').addEventListener('change', saveGeminiSettings);
       document.getElementById('openClassBtn').addEventListener('click', openClassModal);
       document.getElementById('deleteClassBtn').addEventListener('click', deleteSelectedClass);
+      document.getElementById('deleteDraftBtn').addEventListener('click', () => {
+        if (!draftTaskId) {
+          resetForm();
+          return;
+        }
+        google.script.run
+          .withSuccessHandler(() => {
+            resetForm();
+            draftTaskId = null;
+          })
+          .withFailureHandler(err => alert('削除に失敗しました: ' + err.message))
+          .deleteDraftTask(teacherCode, draftTaskId);
+      });
 
       // 3) 回答タイプ選択時に AI ツールを表示 / 非表示
       Array.from(document.getElementsByName('ansType')).forEach(radio => {
@@ -364,6 +382,13 @@
 
       document.getElementById('generateChoicesBtn').addEventListener('click', () => {
         if (aiCredits <= 0) return;
+
+        const clsRadio = document.querySelector('input[name="taskClassRadio"]:checked');
+        const cls = clsRadio ? clsRadio.value : '';
+        const subject = document.getElementById('subject').value.trim();
+        const q = document.getElementById('question').value.trim();
+        const draftPayload = JSON.stringify({ classId: cls, subject, question: q });
+        google.script.run.withSuccessHandler(id => { draftTaskId = id; }).saveDraftTask(teacherCode, draftPayload);
 
         aiCredits--;
         updateAiCreditDisplay();
@@ -401,6 +426,10 @@
         const question = document.getElementById('question').value.trim();
         const subject = document.getElementById('subject').value.trim();
         const persona = document.getElementById('personaInput').value;
+        const clsRadio = document.querySelector('input[name="taskClassRadio"]:checked');
+        const cls = clsRadio ? clsRadio.value : '';
+        const draftPayload = JSON.stringify({ classId: cls, subject, question });
+        google.script.run.withSuccessHandler(id => { draftTaskId = id; }).saveDraftTask(teacherCode, draftPayload);
         container.innerHTML = `Geminiが質問を生成中... <i data-lucide="loader-circle" class="inline-block animate-spin"></i>`;
         renderIcons(document);
 
@@ -503,6 +532,10 @@
             addSubjectHistory(subject);
             resetForm();
             clearDraft();
+            if (draftTaskId) {
+              google.script.run.deleteDraftTask(teacherCode, draftTaskId);
+              draftTaskId = null;
+            }
           })
           .withFailureHandler(err => {
             alert('課題作成中にエラーが発生しました: ' + err.message);

--- a/tests/DraftTask.test.js
+++ b/tests/DraftTask.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadTask(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Task.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('saveDraftTask appends row with draft flag', () => {
+  const sheetStub = { appendRow: jest.fn() };
+  const ssStub = { getSheetByName: jest.fn(() => sheetStub) };
+  const context = {
+    SHEET_TASKS: 'Tasks',
+    Utilities: { getUuid: () => 'uid1' },
+    getSpreadsheetByTeacherCode: () => ssStub
+  };
+  loadTask(context);
+  const payload = JSON.stringify({ classId: 'C1', question: 'Q' });
+  const id = context.saveDraftTask('ABC', payload);
+  expect(id).toBe('uid1');
+  expect(sheetStub.appendRow).toHaveBeenCalled();
+  const row = sheetStub.appendRow.mock.calls[0][0];
+  expect(row[0]).toBe('uid1');
+  expect(row[1]).toBe('C1');
+  expect(row[2]).toBe(payload);
+  expect(row[7]).toBe(1);
+});
+
+test('deleteDraftTask deletes only draft rows', () => {
+  const rows = [
+    ['id1','', 'p1','', new Date(), '', '', 1],
+    ['id2','', 'p2','', new Date(), '', '', '']
+  ];
+  const sheetStub = {
+    getLastRow: jest.fn(() => rows.length + 1),
+    getRange: jest.fn(() => ({ getValues: () => rows })),
+    deleteRow: jest.fn()
+  };
+  const ssStub = { getSheetByName: jest.fn(() => sheetStub) };
+  const context = {
+    SHEET_TASKS: 'Tasks',
+    getSpreadsheetByTeacherCode: () => ssStub
+  };
+  loadTask(context);
+  context.deleteDraftTask('ABC', 'id1');
+  expect(sheetStub.deleteRow).toHaveBeenCalledWith(2);
+  sheetStub.deleteRow.mockClear();
+  context.deleteDraftTask('ABC', 'id2');
+  expect(sheetStub.deleteRow).not.toHaveBeenCalled();
+});

--- a/tests/Migration.test.js
+++ b/tests/Migration.test.js
@@ -21,3 +21,23 @@ test('deleteLegacyApiKeys removes *_apiKey properties', () => {
   context.deleteLegacyApiKeys();
   expect(props).toEqual({ geminiApiKey: 'xyz' });
 });
+
+test('addDraftColumn inserts column when missing', () => {
+  let headers = ['id','class','q','self','date','persona','closed'];
+  const sheetStub = {
+    getLastColumn: jest.fn(() => headers.length),
+    getRange: jest.fn((r, c, num, cols) => {
+      if (num && cols) return { getValues: () => [headers] };
+      return { setValue: v => { headers[c - 1] = v; } };
+    }),
+    insertColumnAfter: jest.fn(pos => { headers.splice(pos, 0, ''); })
+  };
+  const ssStub = { getSheetByName: jest.fn(() => sheetStub) };
+  const context = {
+    SHEET_TASKS: 'Tasks',
+    getSpreadsheetByTeacherCode: () => ssStub
+  };
+  loadMigration(context);
+  context.addDraftColumn('ABC');
+  expect(headers[7]).toBe('draft');
+});


### PR DESCRIPTION
## Summary
- add `saveDraftTask` and `deleteDraftTask` utilities for tasks
- hide drafts from list APIs and student imports
- extend migration script to add a `draft` column
- update management UI to save and delete drafts
- add tests for new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68449f5f4408832b8e83a9f06ecd2d1c