### PR TITLE
Fix board page link in quest.html

### DIFF
--- a/src/quest.html
+++ b/src/quest.html
@@ -237,8 +237,7 @@ async function openTask(task, history) {
   updateProgressBar();
   updateSendButton();
   const link = document.getElementById('viewAnswersBtn');
-  const baseUrl = window.location.origin + window.location.pathname;
-  link.href = `${baseUrl}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${task.id}&grade=${grade}&class=${classroom}&number=${number}`;
+  link.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${task.id}&grade=${grade}&class=${classroom}&number=${number}`;
 }
 
 function renderInputForStep(q, attempt) {


### PR DESCRIPTION
## Summary
- ensure board link uses `SCRIPT_URL` so that the page opens correctly regardless of origin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68449ca83320832b84abb13c621b2bd1