### PR TITLE
Update Gemini model and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ Gemini APIキーは、アプリケーション全体で1つを共有します。
 * API利用時には `getGlobalGeminiApiKey` 関数で安全に呼び出されます。
 * スクリプトプロパティに保存する際のプロパティ名は `geminiApiKey` です。
 
+#### Gemini API 呼び出し例
+
+以下のように `curl` コマンドを使って Gemini API を呼び出すこともできます。
+
+```bash
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=GEMINI_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  -d '{
+    "contents": [
+      {
+        "parts": [
+          {
+            "text": "Explain how AI works in a few words"
+          }
+        ]
+      }
+    ]
+  }'
+```
+
 ## 9. テスト実行
 
 1. 依存インストール

--- a/src/Gemini.gs
+++ b/src/Gemini.gs
@@ -19,8 +19,8 @@ function callGeminiAPI_GAS(teacherCode, prompt, persona) {
     return 'APIキーが設定されていません';
   }
 
-  // ★★★ 変更点：モデル名を gemini-pro から最新のFlashモデルに変更 ★★★
-  const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=' + apiKey;
+  // ★★★ 変更点：モデル名を gemini-2.0-flash に更新 ★★★
+  const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + apiKey;
 
   const payload = {
     contents: [{


### PR DESCRIPTION
## Summary
- use gemini-2.0-flash model in `callGeminiAPI_GAS`
- add example curl command for Gemini API in README

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a3c13340832bbb861f5a79e8bd8a