### PR TITLE
Update board link rendering

### DIFF
--- a/src/quest.html
+++ b/src/quest.html
@@ -216,6 +216,15 @@ function renderLists(tasks, history) {
     div.addEventListener('click', () => openTask(t, history));
     anEl.appendChild(div);
   });
+  const link = document.getElementById('viewAnswersBtn');
+  const firstTask = unanswered[0] || answered[0];
+  if (link) {
+    if (firstTask) {
+      link.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${firstTask.id}&grade=${grade}&class=${classroom}&number=${number}`;
+    } else {
+      link.href = '#';
+    }
+  }
   if (!currentTask && unanswered.length) openTask(unanswered[0], history);
 }
 


### PR DESCRIPTION
## Summary
- ensure `viewAnswersBtn` link is set in `renderLists`
- fall back to first answered task if no unanswered task exists

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a973c954832bacf6588dacbd5681