### PR TITLE
Handle invalid Gemini key decode

### DIFF
--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -352,7 +352,13 @@ function setGlobalGeminiApiKey(apiKey) {
 function getGlobalGeminiApiKey() {
   const props = PropertiesService.getScriptProperties();
   const encoded = props.getProperty('geminiApiKey') || '';
-  return encoded ? Utilities.newBlob(Utilities.base64Decode(encoded)).getDataAsString() : '';
+  if (!encoded) return '';
+  try {
+    return Utilities.newBlob(Utilities.base64Decode(encoded)).getDataAsString();
+  } catch (e) {
+    console.warn('Failed to decode Gemini API key: ' + e.message);
+    return '';
+  }
 }
 
 function setGeminiPersona(teacherCode, persona) {

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -183,3 +183,23 @@ test('saveTeacherSettings persists values correctly and global key handling', ()
   expect(sheetStub.appendRow).toHaveBeenCalledWith(['class', 1, 'A']);
   expect(sheetData[0]).toEqual(['type', 'value1', 'value2']);
 });
+
+test('getGlobalGeminiApiKey handles invalid value gracefully', () => {
+  const props = { geminiApiKey: 'invalid' };
+  const context = {
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: k => props[k]
+      })
+    },
+    Utilities: {
+      base64Decode: jest.fn(() => { throw new Error('bad base64'); }),
+      newBlob: () => ({ getDataAsString: () => 'x' })
+    },
+    console: { warn: jest.fn() }
+  };
+  loadTeacher(context);
+  expect(() => context.getGlobalGeminiApiKey()).not.toThrow();
+  expect(context.getGlobalGeminiApiKey()).toBe('');
+  expect(context.Utilities.base64Decode).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- guard against decoding errors in `getGlobalGeminiApiKey`
- test invalid key handling

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bd8fb444832bb160004cf3ac9bd3