### PR TITLE
Fix board back link for student context

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -206,12 +206,13 @@
       const number = params.get('number');
       const followupSection = document.getElementById('aiFollowupSection');
 
-      if (grade && classroom && number) {
+      const isStudent = grade && classroom && number;
+
+      if (isStudent) {
         if (followupSection) followupSection.classList.add('hidden');
         backLink.href = `?page=quest&teacher=${encodeURIComponent(teacherCode)}&grade=${encodeURIComponent(grade)}&class=${encodeURIComponent(classroom)}&number=${encodeURIComponent(number)}`;
         backLink.innerHTML = '<i data-lucide="arrow-left" class="w-4 h-4"></i><span>クエスト画面に戻る</span>';
-        manageBtn.style.pointerEvents = 'none';
-        manageBtn.style.opacity = '0.5';
+        manageBtn.style.display = 'none';
       } else {
         if (followupSection) {
           followupSection.classList.remove('hidden');
@@ -220,8 +221,7 @@
         backLink.href = `?page=manage&teacher=${encodeURIComponent(teacherCode)}`;
         backLink.innerHTML = '<i data-lucide="arrow-left" class="w-4 h-4"></i><span>管理パネルに戻る</span>';
         manageBtn.href = `?page=manage&teacher=${encodeURIComponent(teacherCode)}`;
-        manageBtn.style.pointerEvents = '';
-        manageBtn.style.opacity = '';
+        manageBtn.style.display = '';
       }
 
       if (taskId) {


### PR DESCRIPTION
## Summary
- adjust link handling in `board.html`
- hide the manage button and point the back link back to the quest screen when the board is opened by students

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bee36c3c832b9e86b5555ee7fbfc