### PR TITLE
Fix Gemini helper usage

### DIFF
--- a/src/Gemini.gs
+++ b/src/Gemini.gs
@@ -92,7 +92,7 @@ function generateProblemPrompt(teacherCode, subject, question, persona) {
   question = String(question || '').trim();
   if (!subject && !question) return '';
   const prompt = `教科「${subject}」で使用する課題として「${question}」に関する問題文を1つ提案してください。`;
-  return callGeminiAPI_GAS(teacherCode, prompt, persona);
+  return callGeminiAPI_GAS(prompt, persona);
 }
 
 /**
@@ -105,7 +105,7 @@ function generateChoicePrompt(teacherCode, question, type, count, persona) {
   count = Number(count) || 1;
   if (!question) return '';
   const prompt = `「${question}」の回答例として${type}を${count}個箇条書きで提示してください。`;
-  return callGeminiAPI_GAS(teacherCode, prompt, persona);
+  return callGeminiAPI_GAS(prompt, persona);
 }
 
 /**
@@ -116,5 +116,5 @@ function generateDeepeningPrompt(teacherCode, question, persona) {
   question = String(question || '').trim();
   if (!question) return '';
   const prompt = `「${question}」について生徒へ更に考えさせる短い質問を2つ箇条書きで提案してください。`;
-  return callGeminiAPI_GAS(teacherCode, prompt, persona);
+  return callGeminiAPI_GAS(prompt, persona);
 }

--- a/tests/Gemini.test.js
+++ b/tests/Gemini.test.js
@@ -53,13 +53,13 @@ test('generateProblemPrompt builds prompt and calls API', () => {
   const calls = [];
   const context = {};
   loadGemini(context);
-  context.callGeminiAPI_GAS = jest.fn((t, p, persona) => {
-    calls.push({ t, p, persona });
+  context.callGeminiAPI_GAS = jest.fn((p, persona) => {
+    calls.push({ p, persona });
     return 'ok';
   });
   const res = context.generateProblemPrompt('T1', 'Math', 'fractions', 'P');
   expect(res).toBe('ok');
-  expect(calls[0].t).toBe('T1');
+  // teacherCode is ignored by callGeminiAPI_GAS
   expect(calls[0].persona).toBe('P');
   expect(calls[0].p).toContain('Math');
   expect(calls[0].p).toContain('fractions');
@@ -69,13 +69,13 @@ test('generateChoicePrompt builds prompt and calls API', () => {
   const calls = [];
   const context = {};
   loadGemini(context);
-  context.callGeminiAPI_GAS = jest.fn((t, p, persona) => {
-    calls.push({ t, p, persona });
+  context.callGeminiAPI_GAS = jest.fn((p, persona) => {
+    calls.push({ p, persona });
     return 'ok';
   });
   const res = context.generateChoicePrompt('T2', 'What?', '単語', 3, 'P');
   expect(res).toBe('ok');
-  expect(calls[0].t).toBe('T2');
+  // teacherCode is ignored by callGeminiAPI_GAS
   expect(calls[0].persona).toBe('P');
   expect(calls[0].p).toContain('What?');
   expect(calls[0].p).toContain('単語');
@@ -86,13 +86,13 @@ test('generateDeepeningPrompt builds prompt and calls API', () => {
   const calls = [];
   const context = {};
   loadGemini(context);
-  context.callGeminiAPI_GAS = jest.fn((t, p, persona) => {
-    calls.push({ t, p, persona });
+  context.callGeminiAPI_GAS = jest.fn((p, persona) => {
+    calls.push({ p, persona });
     return 'ok';
   });
   const res = context.generateDeepeningPrompt('T3', 'Explain gravity', 'P');
   expect(res).toBe('ok');
-  expect(calls[0].t).toBe('T3');
+  // teacherCode is ignored by callGeminiAPI_GAS
   expect(calls[0].persona).toBe('P');
   expect(calls[0].p).toContain('Explain gravity');
 });


### PR DESCRIPTION
## Summary
- update Gemini helper functions to use `callGeminiAPI_GAS(prompt, persona)`
- adjust tests to match new parameter order

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e155385c832b91a65dd4ff244821