### PR TITLE
Implement student login tracking

### DIFF
--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -122,7 +122,7 @@ function initTeacher(passcode) {
     {
       name: SHEET_STUDENTS,
       color: "4285f4",
-      header: ['生徒ID', '学年', '組', '番号', '初回ログイン日時'],
+      header: ['生徒ID', '学年', '組', '番号', '初回ログイン日時', '最終ログイン日時', '累計ログイン回数', '累積XP', '現在レベル', '最終獲得トロフィーID'],
       description: "ログインした生徒の情報が記録されます。"
     },
     {

--- a/tests/Student.test.js
+++ b/tests/Student.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadStudent(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Student.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('updateStudentLogin increments count and sets timestamp', () => {
+  const sheetData = [
+    ['生徒ID','学年','組','番号','初回ログイン日時','最終ログイン日時','累計ログイン回数','累積XP','現在レベル','最終獲得トロフィーID'],
+    ['1-1-1',1,'A',1,new Date('2021-01-01'),new Date('2021-01-01'),1,0,1,'']
+  ];
+  const sheetStub = {
+    getDataRange: jest.fn(() => ({ getValues: () => sheetData })),
+    getRange: jest.fn((r,c,rows,cols) => ({
+      getValue: () => sheetData[r-1][c-1],
+      setValues: values => {
+        sheetData[r-1][c-1] = values[0][0];
+        sheetData[r-1][c] = values[0][1];
+      }
+    }))
+  };
+  const ssStub = { getSheetByName: jest.fn(() => sheetStub) };
+  const context = {
+    SHEET_STUDENTS: 'Students',
+    getSpreadsheetByTeacherCode: () => ssStub
+  };
+  loadStudent(context);
+  const before = sheetData[1][6];
+  const beforeDate = sheetData[1][5];
+  const result = context.updateStudentLogin('ABC','1-1-1');
+  expect(result).toBe(true);
+  expect(sheetData[1][6]).toBe(before + 1);
+  expect(sheetData[1][5]).not.toBe(beforeDate);
+  expect(typeof sheetData[1][5].getTime).toBe('function');
+});


### PR DESCRIPTION
## Summary
- expand `initStudent` to populate login related fields
- add helper to update login timestamp and count
- expose `updateStudentLogin`
- create basic unit test for login updates
- include login columns when initializing Students sheet

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e1672f3c832bbe7bc8681889af49