### PR TITLE
Align sheet schema with documentation

### DIFF
--- a/src/Board.gs
+++ b/src/Board.gs
@@ -7,19 +7,17 @@ function listBoard(teacherCode) {
   }
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];
-  // 10列目まで取得
-  const data = sheet.getRange(2, 1, lastRow - 1, 10).getValues();
+  // 12列目まで取得
+  const data = sheet.getRange(2, 1, lastRow - 1, 12).getValues();
   const sliceStart = Math.max(0, data.length - 30);
   const slice = data.slice(sliceStart).reverse();
   return slice.map(row => ({
-    studentId: row[1],
-    answer: row[3],
-    earnedXp: row[4],
-    totalXp: row[5],
-    level: row[6],
-    trophies: row[7],
-    aiCalls: row[8],
-    attempts: row[9]
+    studentId: row[0],
+    answer: row[7],
+    earnedXp: row[8],
+    totalXp: row[9],
+    level: row[10],
+    trophies: row[11]
   }));
 }
 
@@ -34,17 +32,15 @@ function listTaskBoard(teacherCode, taskId) {
   if (!sheet) return [];
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];
-  const data = sheet.getRange(2, 1, lastRow - 1, 10).getValues();
-  const filtered = data.filter(r => r[2] === taskId).reverse();
+  const data = sheet.getRange(2, 1, lastRow - 1, 12).getValues();
+  const filtered = data.filter(r => r[1] === taskId).reverse();
   return filtered.map(row => ({
-    studentId: row[1],
-    answer: row[3],
-    earnedXp: row[4],
-    totalXp: row[5],
-    level: row[6],
-    trophies: row[7],
-    aiCalls: row[8],
-    attempts: row[9]
+    studentId: row[0],
+    answer: row[7],
+    earnedXp: row[8],
+    totalXp: row[9],
+    level: row[10],
+    trophies: row[11]
   }));
 }
 

--- a/src/Gemini.gs
+++ b/src/Gemini.gs
@@ -62,13 +62,10 @@ function logToSpreadsheet(logData) {
   const sheet = ss.getSheetByName(SHEET_AI_FEEDBACK);
   if (!sheet) return;
   sheet.appendRow([
-    new Date(),
-    logData.studentId,
-    logData.taskId,
-    logData.attempt,
-    logData.aiCalls,
-    logData.answer || '',
-    logData.feedback || ''
+    Utilities.getUuid(),
+    logData.taskId || '',
+    logData.feedback || '',
+    new Date()
   ]);
 }
 

--- a/src/Migration.gs
+++ b/src/Migration.gs
@@ -13,18 +13,23 @@ function deleteLegacyApiKeys() {
 }
 
 /**
- * addDraftColumn(teacherCode):
- * 課題シートに draft 列が無ければ追加
+ * upgradeStudentsSheet(teacherCode):
+ * 旧バージョンの Students シートに追加列を付与
  */
-function addDraftColumn(teacherCode) {
+function upgradeStudentsSheet(teacherCode) {
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) return false;
-  const sheet = ss.getSheetByName(SHEET_TASKS);
+  const sheet = ss.getSheetByName(SHEET_STUDENTS);
   if (!sheet) return false;
+  const required = ['生徒ID','学年','組','番号','初回ログイン日時','最終ログイン日時','累計ログイン回数','累積XP','現在レベル','最終獲得トロフィーID'];
   const lastCol = sheet.getLastColumn();
-  const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
-  if (headers.includes('draft')) return true;
-  sheet.insertColumnAfter(Math.max(7, lastCol));
-  sheet.getRange(1, Math.max(8, lastCol + 1)).setValue('draft');
+  let headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  if (headers.length < required.length) {
+    for (let i = headers.length; i < required.length; i++) {
+      sheet.insertColumnAfter(i);
+    }
+    headers = sheet.getRange(1, 1, 1, required.length).getValues()[0];
+  }
+  sheet.getRange(1, 1, 1, required.length).setValues([required]);
   return true;
 }

--- a/src/Student.gs
+++ b/src/Student.gs
@@ -91,7 +91,7 @@ function initStudent(teacherCode, grade, classroom, number) {
     }
   }
   if (studentRowIndex === -1) {
-    studentListSheet.appendRow([studentId, grade, classroom, number, new Date()]);
+    studentListSheet.appendRow([studentId, grade, classroom, number, new Date(), new Date(), 1, 0, 0, '']);
   } else if (studentListData[studentRowIndex][0] !== studentId) {
     studentListSheet.getRange(studentRowIndex + 1, 1).setValue(studentId);
   }
@@ -142,13 +142,18 @@ function initStudent(teacherCode, grade, classroom, number) {
   if (subsSheet && tasksSheet) {
     const last = tasksSheet.getLastRow();
     if (last >= 2) {
-      const rows = tasksSheet.getRange(2, 1, last - 1, 8).getValues();
+      const rows = tasksSheet.getRange(2, 1, last - 1, 5).getValues();
       rows.forEach(r => {
-        if (String(r[6] || '').toLowerCase() === 'closed') return;
-        if (String(r[7] || '') === '1') return;
         const taskId = r[0];
-        const createdAt = r[3];
-        subsSheet.appendRow([createdAt, studentId, taskId, '', 0, 0, 0, '', 0, 0]);
+        const createdAt = r[4];
+        let questionText = '';
+        try {
+          const parsed = JSON.parse(r[2]);
+          questionText = parsed.question || r[2];
+        } catch (e) {
+          questionText = r[2];
+        }
+        subsSheet.appendRow([studentId, taskId, questionText, createdAt, '', '', '', '', 0, 0, 0, '']);
       });
     }
   }
@@ -175,10 +180,8 @@ function initStudent(teacherCode, grade, classroom, number) {
         Object.keys(map).forEach(id => {
           if (map[id] === `${grade}-${classroom}`) classId = id;
         });
-        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 8).getValues();
+        const taskData = taskSheet.getRange(2, 1, lastRow - 1, 5).getValues();
         taskData.forEach(row => {
-          if (String(row[6] || '').toLowerCase() === 'closed') return;
-          if (String(row[7] || '') === '1') return;
           if (classId && String(row[1]) !== String(classId)) return;
           const taskId        = row[0];
           const payloadAsJson = row[2];

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -116,25 +116,25 @@ function initTeacher(passcode) {
     {
       name: SHEET_TASKS,
       color: "ff9900",
-      header: ['ID', 'ClassID', '問題データ(JSON)', '自己評価許可', '作成日時', 'ペルソナ', '状態', 'draft'],
+      header: ['ID', 'ClassID', '問題データ(JSON)', '自己評価許可', '作成日時'],
       description: "作成された課題の一覧です。"
     },
     {
       name: SHEET_STUDENTS,
       color: "4285f4",
-      header: ['生徒ID', '学年', '組', '番号', '初回ログイン日時'],
+      header: ['生徒ID', '学年', '組', '番号', '初回ログイン日時', '最終ログイン日時', '累計ログイン回数', '累積XP', '現在レベル', '最終獲得トロフィーID'],
       description: "ログインした生徒の情報が記録されます。"
     },
     {
       name: SHEET_SUBMISSIONS,
       color: "008080",
-      header: ['日時', '生徒ID', '課題ID', '回答概要', '付与XP', '累積XP', 'レベル', 'トロフィー', 'AI呼び出し回数', '回答回数'],
+      header: ['生徒ID', '課題ID', '問題文', '開始日時', '提出日時', '成果物URL', '問題概要', '回答概要', '付与XP', '累積XP', 'レベル', 'トロフィー'],
       description: "全生徒の回答の概要（ボード表示用）です。"
     },
     {
       name: SHEET_AI_FEEDBACK,
       color: "ff4444",
-      header: ['日時', '生徒ID', '課題ID', '回答回数', 'AI呼び出し回数', '回答本文', 'フィードバック内容'],
+      header: ['LogID', 'SubmissionID', 'フィード内容', '生成日時'],
       description: "Gemini API からのフィードバックログです。"
     },
     {

--- a/tests/DraftTask.test.js
+++ b/tests/DraftTask.test.js
@@ -7,7 +7,7 @@ function loadTask(context) {
   vm.runInNewContext(code, context);
 }
 
-test('saveDraftTask appends row with draft flag', () => {
+test('saveDraftTask appends row with new schema', () => {
   const sheetStub = { appendRow: jest.fn() };
   const ssStub = { getSheetByName: jest.fn(() => sheetStub) };
   const context = {
@@ -21,16 +21,17 @@ test('saveDraftTask appends row with draft flag', () => {
   expect(id).toBe('uid1');
   expect(sheetStub.appendRow).toHaveBeenCalled();
   const row = sheetStub.appendRow.mock.calls[0][0];
+  expect(row.length).toBe(5);
   expect(row[0]).toBe('uid1');
   expect(row[1]).toBe('C1');
   expect(row[2]).toBe(payload);
-  expect(row[7]).toBe(1);
+  expect(Object.prototype.toString.call(row[4])).toBe('[object Date]');
 });
 
-test('deleteDraftTask deletes only draft rows', () => {
+test('deleteDraftTask deletes row by id', () => {
   const rows = [
-    ['id1','', 'p1','', new Date(), '', '', 1],
-    ['id2','', 'p2','', new Date(), '', '', '']
+    ['id1','', 'p1','', new Date()],
+    ['id2','', 'p2','', new Date()]
   ];
   const sheetStub = {
     getLastRow: jest.fn(() => rows.length + 1),
@@ -45,7 +46,4 @@ test('deleteDraftTask deletes only draft rows', () => {
   loadTask(context);
   context.deleteDraftTask('ABC', 'id1');
   expect(sheetStub.deleteRow).toHaveBeenCalledWith(2);
-  sheetStub.deleteRow.mockClear();
-  context.deleteDraftTask('ABC', 'id2');
-  expect(sheetStub.deleteRow).not.toHaveBeenCalled();
 });

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -75,7 +75,7 @@ test('initTeacher creates StudyQuest_DB when none exists', () => {
   expect(context.SpreadsheetApp.create).toHaveBeenCalledWith('StudyQuest_DB');
 });
 
-test('initTeacher tasks sheet header includes draft column', () => {
+test('initTeacher creates sheets with documented headers', () => {
   const props = {};
   const dummyRange = {
     setFontWeight: jest.fn().mockReturnThis(),
@@ -135,8 +135,14 @@ test('initTeacher tasks sheet header includes draft column', () => {
   context.getSpreadsheetByTeacherCode = () => ssStub;
   context.generateTeacherCode = jest.fn(() => 'ABC123');
   context.initTeacher('kyoushi');
-  const header = inserted['Tasks'].appendRow.mock.calls[0][0];
-  expect(header[header.length-1]).toBe('draft');
+  const taskHeader = inserted['Tasks'].appendRow.mock.calls[0][0];
+  const studentHeader = inserted['Students'].appendRow.mock.calls[0][0];
+  const subsHeader = inserted['Submissions'].appendRow.mock.calls[0][0];
+  const aiHeader = inserted['AI'].appendRow.mock.calls[0][0];
+  expect(taskHeader).toEqual(['ID','ClassID','問題データ(JSON)','自己評価許可','作成日時']);
+  expect(studentHeader.length).toBe(10);
+  expect(subsHeader.length).toBe(12);
+  expect(aiHeader).toEqual(['LogID','SubmissionID','フィード内容','生成日時']);
 });
 
 test('saveTeacherSettings persists values correctly and global key handling', () => {


### PR DESCRIPTION
## Summary
- create spreadsheet tabs with new headers
- update task, student, board and Gemini logic to match new column order
- migrate existing Students sheets to add new columns
- adjust Jest tests for updated schemas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e11d0b8c832b8140e2c0ebd037f2