### PR TITLE
Fix submission placeholder columns

### DIFF
--- a/src/Student.gs
+++ b/src/Student.gs
@@ -162,9 +162,25 @@ function initStudent(teacherCode, grade, classroom, number) {
       rows.forEach(r => {
         if (String(r[6] || '').toLowerCase() === 'closed') return;
         if (String(r[7] || '') === '1') return;
-        const taskId = r[0];
-        const createdAt = r[3];
-        subsSheet.appendRow([createdAt, studentId, taskId, '', 0, 0, 0, '', 0, 0]);
+        const taskId     = r[0];
+        const payload    = r[2];
+        const startTime  = r[4];
+        let questionText = '';
+        try {
+          const parsed = JSON.parse(payload);
+          questionText = parsed.question || payload;
+        } catch (e) {
+          questionText = payload;
+        }
+        subsSheet.appendRow([
+          studentId,
+          taskId,
+          questionText,
+          startTime || '',
+          '', '', '', '',
+          0, 0, 0,
+          ''
+        ]);
       });
     }
   }

--- a/tests/Student.test.js
+++ b/tests/Student.test.js
@@ -85,6 +85,7 @@ test('initStudent adds placeholder rows to Submissions', () => {
   context.initStudent('ABC', 1, 1, 1);
   expect(subsSheet.appendRow).toHaveBeenCalled();
   const row = subsSheet.appendRow.mock.calls[0][0];
+  expect(row.length).toBe(12);
   expect(row).toEqual([
     '1-1-1',
     't1',

--- a/tests/Student.test.js
+++ b/tests/Student.test.js
@@ -36,3 +36,62 @@ test('updateStudentLogin increments count and sets timestamp', () => {
   expect(sheetData[1][5]).not.toBe(beforeDate);
   expect(typeof sheetData[1][5].getTime).toBe('function');
 });
+
+test('initStudent adds placeholder rows to Submissions', () => {
+  const students = [
+    ['生徒ID','学年','組','番号','初回ログイン日時','最終ログイン日時','累計ログイン回数','累積XP','現在レベル','最終獲得トロフィーID']
+  ];
+  const studentSheetStub = {
+    appendRow: jest.fn(),
+    setTabColor: jest.fn(),
+    getSheetId: jest.fn(() => 2),
+    getLastRow: jest.fn(() => 1)
+  };
+  const studentListSheet = {
+    getDataRange: jest.fn(() => ({ getValues: () => students })),
+    appendRow: jest.fn(row => { students.push(row); }),
+    getLastRow: jest.fn(() => students.length),
+    getRange: jest.fn(() => ({ setValue: jest.fn() }))
+  };
+  const subsSheet = { appendRow: jest.fn() };
+  const taskRows = [[
+    't1', '1', '{"question":"Q1"}', '', new Date('2024-01-01'), '', '', ''
+  ]];
+  const tasksSheet = {
+    getLastRow: jest.fn(() => taskRows.length + 1),
+    getRange: jest.fn(() => ({ getValues: () => taskRows }))
+  };
+  const ssStub = {
+    getSheetByName: jest.fn(name => {
+      if (name === 'Students') return studentListSheet;
+      if (name === 'Submissions') return subsSheet;
+      if (name === 'Tasks') return tasksSheet;
+      return null;
+    }),
+    getSheets: jest.fn(() => []),
+    insertSheet: jest.fn(() => studentSheetStub),
+    getUrl: jest.fn(() => 'url')
+  };
+  const context = {
+    SHEET_STUDENTS: 'Students',
+    SHEET_SUBMISSIONS: 'Submissions',
+    SHEET_TASKS: 'Tasks',
+    SHEET_TOC: 'TOC',
+    STUDENT_SHEET_PREFIX: 'stu_',
+    getSpreadsheetByTeacherCode: () => ssStub,
+    getClassIdMap: jest.fn(() => ({}))
+  };
+  loadStudent(context);
+  context.initStudent('ABC', 1, 1, 1);
+  expect(subsSheet.appendRow).toHaveBeenCalled();
+  const row = subsSheet.appendRow.mock.calls[0][0];
+  expect(row).toEqual([
+    '1-1-1',
+    't1',
+    'Q1',
+    taskRows[0][4],
+    '', '', '', '',
+    0, 0, 0,
+    ''
+  ]);
+});


### PR DESCRIPTION
## Summary
- ensure placeholder rows inserted for new students fill 12 columns in `SHEET_SUBMISSIONS`
- add regression test for the new placeholder format

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e819f12c832b9fcd48c037117c6d