### PR TITLE
Simplify board columns

### DIFF
--- a/src/Board.gs
+++ b/src/Board.gs
@@ -7,7 +7,7 @@ function listBoard(teacherCode) {
   }
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];
-  const lastCol = Math.min(sheet.getLastColumn(), 14);
+  const lastCol = Math.min(sheet.getLastColumn(), 12);
   const data = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
   const sliceStart = Math.max(0, data.length - 30);
   const slice = data.slice(sliceStart).reverse();
@@ -17,9 +17,7 @@ function listBoard(teacherCode) {
     earnedXp: row[8],
     totalXp: row[9],
     level: row[10],
-    trophies: row[11],
-    aiCalls: row[12] || 0,
-    attempts: row[13] || 0
+    trophies: row[11]
   }));
 }
 
@@ -34,7 +32,7 @@ function listTaskBoard(teacherCode, taskId) {
   if (!sheet) return [];
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];
-  const lastCol = Math.min(sheet.getLastColumn(), 14);
+  const lastCol = Math.min(sheet.getLastColumn(), 12);
   const data = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
   const filtered = data.filter(r => r[1] === taskId).reverse();
   return filtered.map(row => ({
@@ -43,9 +41,7 @@ function listTaskBoard(teacherCode, taskId) {
     earnedXp: row[8],
     totalXp: row[9],
     level: row[10],
-    trophies: row[11],
-    aiCalls: row[12] || 0,
-    attempts: row[13] || 0
+    trophies: row[11]
   }));
 }
 

--- a/src/board.html
+++ b/src/board.html
@@ -273,7 +273,6 @@
             <div class="text-xs space-y-1 text-gray-400">
               <div class="flex justify-between items-center"><span>ステータス:</span><span class="font-bold text-amber-300">Lv. ${r.level}</span></div>
               <div class="flex justify-between items-center"><span>獲得XP:</span><span class="font-bold text-green-400">+${r.earnedXp} XP</span></div>
-              <div class="flex justify-between items-center"><span>AIヒント / 回答回数:</span><span>${r.aiCalls}/2回, ${r.attempts}/3回</span></div>
             </div>
           `;
           card.addEventListener('click', () => {

--- a/tests/Board.test.js
+++ b/tests/Board.test.js
@@ -55,9 +55,7 @@ test('listBoard reads new submission columns', () => {
     earnedXp: 3,
     totalXp: 13,
     level: 2,
-    trophies: '',
-    aiCalls: 0,
-    attempts: 0
+    trophies: ''
   });
   expect(rows[1].studentId).toBe('s1');
 });


### PR DESCRIPTION
## Summary
- streamline board APIs to only read 12 columns from Submissions
- remove aiCalls/attempts statistics from board view
- update unit tests for new board mapping

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e8ef021c832ba46224cc4c5c45ba