### PR TITLE
Update manage panel for simpler Gemini test

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -184,7 +184,11 @@
                             <h3 class="font-bold text-pink-400 mb-2">AIペルソナ設定</h3>
                             <div class="space-y-2 text-sm">
                                 <input id="personaInput" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600" placeholder="例: 優しく導く先生" />
-                                <input id="geminiApiKeyInput" type="text" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600" placeholder="Gemini API Key" />
+                                <div class="space-y-1" id="geminiTestArea">
+                                    <input id="geminiTestPrompt" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600" value="こんにちは" />
+                                    <button type="button" id="geminiTestBtn" class="w-full game-btn bg-purple-600 text-white px-4 py-2 rounded-lg font-bold border-purple-800 hover:bg-purple-500 text-sm">Gemini テスト送信</button>
+                                    <div id="geminiTestResult" class="text-xs text-gray-300 whitespace-pre-wrap"></div>
+                                </div>
                                 <span id="apiStatus" class="text-green-400 text-xs hidden"></span>
                             </div>
                         </div>
@@ -232,7 +236,7 @@
                             </div>
                         </div>
                         <div id="aiToolsSection" class="space-y-4 hidden">
-                            <div class="p-3 rounded-lg ai-tool-panel space-y-3">
+                            <div id="choiceTool" class="p-3 rounded-lg ai-tool-panel space-y-3">
                                 <div class="flex justify-between items-center">
                                     <label class="font-bold text-purple-300 flex items-center gap-1"><i data-lucide="sparkles" class="w-4 h-4"></i>Geminiで選択肢を生成</label>
                                     <div id="aiCredit" class="text-sm text-amber-300 font-bold">生成クレジット: 💎 💎 💎</div>
@@ -253,7 +257,7 @@
                                     <div id="generationHistory" class="hidden mt-2 p-2 bg-gray-900/50 rounded-md space-y-2"></div>
                                 </div>
                             </div>
-                            <div class="p-3 rounded-lg ai-tool-panel space-y-3">
+                            <div id="followupTool" class="p-3 rounded-lg ai-tool-panel space-y-3">
                                 <label class="font-bold text-purple-300 flex items-center gap-1"><i data-lucide="messages-square" class="w-4 h-4"></i>Geminiによる深掘りの質問例</label>
                                 <button type="button" id="generateFollowupBtn" class="w-full game-btn bg-purple-600 text-white px-4 py-2 rounded-lg font-bold border-purple-800 hover:bg-purple-500 text-sm">質問を生成</button>
                                 <div id="followupSuggestions" class="text-sm text-gray-300 bg-gray-900/50 p-2 rounded-md min-h-[40px] whitespace-pre-wrap"></div>
@@ -357,8 +361,19 @@
       document.getElementById('subject').addEventListener('input', saveDraft);
       document.getElementById('question').addEventListener('input', saveDraft);
       document.getElementById('personaInput').addEventListener('change', saveGeminiSettings);
-      const apiInput = document.getElementById('geminiApiKeyInput');
-      if (apiInput) apiInput.addEventListener('change', saveGeminiSettings);
+      const testBtn = document.getElementById('geminiTestBtn');
+      if (testBtn) {
+        testBtn.addEventListener('click', () => {
+          const prompt = document.getElementById('geminiTestPrompt').value;
+          const resultEl = document.getElementById('geminiTestResult');
+          const persona = document.getElementById('personaInput').value;
+          resultEl.textContent = '送信中...';
+          google.script.run
+            .withSuccessHandler(res => { resultEl.textContent = res; })
+            .withFailureHandler(err => { resultEl.textContent = '失敗: ' + err.message; })
+            .callGeminiAPI_GAS(prompt, persona);
+        });
+      }
       document.getElementById('openClassBtn').addEventListener('click', openClassModal);
       document.getElementById('deleteClassBtn').addEventListener('click', deleteSelectedClass);
       document.getElementById('deleteDraftBtn').addEventListener('click', () => {
@@ -375,13 +390,38 @@
           .deleteDraftTask(teacherCode, draftTaskId);
       });
 
-      // 3) 回答タイプ選択時に AI ツールを表示 / 非表示
+      // 3) 回答タイプ選択時のAIツール表示制御
       Array.from(document.getElementsByName('ansType')).forEach(radio => {
         radio.addEventListener('change', e => {
-          const area = document.getElementById('aiToolsSection');
-          area.classList.toggle('hidden', e.target.value === 'text');
+          const isText = e.target.value === 'text';
+          document.getElementById('aiToolsSection').classList.remove('hidden');
+          document.getElementById('choiceTool').classList.toggle('hidden', isText);
+          if (!isText) {
+            const cnt = parseInt(document.getElementById('choiceCount').value, 10) || 1;
+            renderOptionInputs(Array(cnt).fill(''));
+          }
         });
       });
+
+      function updateToolVisibility() {
+        const radio = document.querySelector('input[name="ansType"]:checked');
+        if (!radio) return;
+        const isText = radio.value === 'text';
+        document.getElementById('aiToolsSection').classList.remove('hidden');
+        document.getElementById('choiceTool').classList.toggle('hidden', isText);
+        if (!isText) {
+          const cnt = parseInt(document.getElementById('choiceCount').value, 10) || 1;
+          renderOptionInputs(Array(cnt).fill(''));
+        }
+      }
+
+      const countInput = document.getElementById('choiceCount');
+      if (countInput) {
+        countInput.addEventListener('input', e => {
+          const n = parseInt(e.target.value, 10) || 0;
+          renderOptionInputs(Array(n).fill(''));
+        });
+      }
 
       document.getElementById('generateChoicesBtn').addEventListener('click', () => {
         if (aiCredits <= 0) return;
@@ -409,6 +449,7 @@
           .withSuccessHandler(res => {
             const choices = res.split(/\n|・/).map(s => s.trim()).filter(s => s);
             generationHistory.push(choices);
+            document.getElementById('choiceCount').value = choices.length;
             renderOptionInputs(choices);
             updateGenerationHistory();
             if (aiCredits <= 0) {
@@ -633,8 +674,6 @@
         google.script.run
           .withSuccessHandler(res => {
             document.getElementById('personaInput').value = res.persona || '';
-            const apiInput = document.getElementById('geminiApiKeyInput');
-            if (apiInput) apiInput.value = res.apiKey || '';
             document.getElementById('apiStatus').classList.add('hidden');
           })
           .getGeminiSettings(teacherCode);
@@ -669,7 +708,6 @@
       // Gemini 設定を保存
       function saveGeminiSettings() {
         const persona = document.getElementById('personaInput').value;
-        const apiKey = document.getElementById('geminiApiKeyInput').value;
         google.script.run
           .withSuccessHandler(() => {
             document.getElementById('apiStatus').textContent = '保存しました';
@@ -679,7 +717,7 @@
             document.getElementById('apiStatus').textContent = '保存に失敗: ' + err.message;
             document.getElementById('apiStatus').classList.remove('hidden');
           })
-          .setGeminiSettings(teacherCode, apiKey, persona);
+          .setGeminiSettings(teacherCode, undefined, persona);
       }
 
       function loadSubjectHistory() {
@@ -758,7 +796,8 @@
         document.getElementById('question').value = '';
         const textRadio = document.querySelector('input[name="ansType"][value="text"]');
         if (textRadio) textRadio.checked = true;
-        document.getElementById('aiToolsSection').classList.add('hidden');
+        document.getElementById('aiToolsSection').classList.remove('hidden');
+        document.getElementById('choiceTool').classList.add('hidden');
         resetOptionInputs();
         document.getElementById('selfEval').checked = false;
         clearDraft();
@@ -810,8 +849,11 @@
         document.getElementById('question').value = data.question || '';
         const radio = document.querySelector(`input[name="ansType"][value="${data.type}"]`);
         if (radio) radio.checked = true;
-        if (data.type !== 'text') {
-          document.getElementById('aiToolsSection').classList.remove('hidden');
+        document.getElementById('aiToolsSection').classList.remove('hidden');
+        const isText = data.type === 'text';
+        document.getElementById('choiceTool').classList.toggle('hidden', isText);
+        if (!isText) {
+          document.getElementById('choiceCount').value = (data.choices || []).length || 1;
           renderOptionInputs(data.choices || []);
         }
         const clsCheckbox = document.querySelector(`#taskClassButtons input[value="${task.classId}"]`);
@@ -820,6 +862,7 @@
         document.querySelectorAll('#currentClassCard .class-card').forEach(c => {
           c.classList.toggle('selected', c.dataset.id === String(task.classId));
         });
+        updateToolVisibility();
       }
 
       /**
@@ -1023,6 +1066,7 @@
       updateDateTime();
       setInterval(updateDateTime, 1000);
       renderIcons(document);
+      updateToolVisibility();
       if (window.gsap) {
         gsap.from('main', { opacity: 0, y: 20, duration: 0.6 });
       }


### PR DESCRIPTION
## Summary
- simplify AI settings in manage panel
- add Gemini test sender and dynamic choice fields
- show followup tool even for text questions
- auto update option inputs when count changes

## Testing
- `scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ee2cb474832b98ba7e416381c3e0