### PR TITLE
Improve board UX

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -91,10 +91,6 @@
         <i data-lucide="settings" class="w-4 h-4"></i>
         <span>管理パネル</span>
       </a>
-      <button type="button" id="closeTaskBtn" class="game-btn bg-red-600 text-white px-4 py-2 rounded-lg font-bold border-red-800 hover:bg-red-500 text-sm flex items-center gap-2 flex-shrink-0 hidden">
-        <i data-lucide="square-x" class="w-4 h-4"></i>
-        <span>クエストを閉じる</span>
-      </button>
     </header>
 
     <section id="aiFollowupSection" class="glass-panel rounded-xl p-4 mb-4 shadow-lg hidden space-y-2">
@@ -200,7 +196,6 @@
       }
       const backLink = document.getElementById('backLink');
       const manageBtn = document.getElementById('manageBtn');
-      const closeBtn = document.getElementById('closeTaskBtn');
       const grade = params.get('grade') || gradeParam;
       const classroom = params.get('class') || classParam;
       const number = params.get('number') || numberParam;
@@ -225,7 +220,6 @@
       }
 
       if (taskId) {
-        if (closeBtn) closeBtn.classList.remove('hidden');
         document.getElementById('headingLabel').textContent = '課題別ボード';
         google.script.run.withSuccessHandler(tasks => {
           const t = tasks.find(x => x.id === taskId);
@@ -246,7 +240,6 @@
         google.script.run.withSuccessHandler(id => {
           taskId = id || null;
           if (taskId) {
-            if (closeBtn) closeBtn.classList.remove('hidden');
             document.getElementById('headingLabel').textContent = '課題別ボード';
             google.script.run.withSuccessHandler(tasks => {
               const t = tasks.find(x => x.id === taskId);
@@ -298,6 +291,7 @@
             <div class="text-xs space-y-1 text-gray-400">
               <div class="flex justify-between items-center"><span>ステータス:</span><span class="font-bold text-amber-300">Lv. ${r.level}</span></div>
               <div class="flex justify-between items-center"><span>獲得XP:</span><span class="font-bold text-green-400">+${r.earnedXp} XP</span></div>
+              <div class="flex justify-between items-center"><span>累計XP:</span><span class="font-bold text-green-300">${r.totalXp} XP</span></div>
             </div>
           `;
           card.addEventListener('click', () => {
@@ -370,18 +364,6 @@
         });
       }
 
-      if (closeBtn) {
-        closeBtn.addEventListener('click', () => {
-          if (!confirm('このクエストを閉じますか？')) return;
-          google.script.run
-            .withSuccessHandler(() => {
-              closeBtn.disabled = true;
-              closeBtn.textContent = '閉じました';
-            })
-            .withFailureHandler(err => alert('クエストを閉じられません: ' + err.message))
-            .closeTask(teacherCode, taskId);
-        });
-      }
 
       if (!taskId) {
         // loadBoard will be called after resolving active task

--- a/src/manage.html
+++ b/src/manage.html
@@ -954,10 +954,8 @@
             <div class="flex justify-between items-center mt-2 pr-8">
               <p class="text-sm text-gray-400">${x.date}</p>
             </div>
-            <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2">
-              <button class="closeBtn p-1" data-id="${x.id}" title="このクエストを閉じる">
-                <i data-icon="SquareX" class="w-6 h-6 text-red-300"></i>
-              </button>
+            <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2 text-xs">
+              <span class="closeBtn text-red-300 underline cursor-pointer" data-id="${x.id}" title="このクエストを閉じる">クエストを閉じる</span>
               <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
                 <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
               </button>


### PR DESCRIPTION
## Summary
- display total XP on answer board
- remove close quest button from board
- add "クエストを閉じる" link to quest cards in manage panel

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845031f8f98832bb999152e9f70ed86