### PR TITLE
Add quest close functionality and bonus XP

### DIFF
--- a/src/Task.gs
+++ b/src/Task.gs
@@ -153,11 +153,45 @@ function closeTask(teacherCode, taskId) {
   }
   const subs = ss.getSheetByName(SHEET_SUBMISSIONS);
   if (subs && subs.getLastRow() > 1) {
-    const subIds = subs.getRange(2, 2, subs.getLastRow() - 1, 1).getValues().flat();
-    subIds.forEach((v, i) => {
-      if (v === taskId) subs.getRange(i + 2, 13).setValue(1);
-    });
+    const range = subs.getRange(2, 1, subs.getLastRow() - 1, 13);
+    const data = range.getValues();
+    const bonusMap = {};
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      if (row[1] === taskId) {
+        if (Number(row[12]) === 1) {
+          bonusMap[row[0]] = true;
+        }
+        row[12] = 1;
+      }
+    }
+    range.setValues(data);
+    Object.keys(bonusMap).forEach(id => giveBonusXp_(ss, id, 5));
   }
+}
+
+function giveBonusXp_(ss, studentId, amount) {
+  const sheet = ss.getSheetByName(SHEET_STUDENTS);
+  if (!sheet) return;
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][0]).trim() === studentId) {
+      const total = Number(data[i][7] || 0) + amount;
+      sheet.getRange(i + 1, 8).setValue(total);
+      sheet.getRange(i + 1, 9).setValue(calcLevelFromXp_(total));
+      break;
+    }
+  }
+}
+
+function calcLevelFromXp_(totalXp) {
+  let level = 1;
+  let xp = totalXp;
+  while (xp >= level * 100) {
+    xp -= level * 100;
+    level++;
+  }
+  return level;
 }
 
 /**

--- a/src/board.html
+++ b/src/board.html
@@ -91,6 +91,10 @@
         <i data-lucide="settings" class="w-4 h-4"></i>
         <span>管理パネル</span>
       </a>
+      <button id="closeQuestBtn" class="game-btn bg-red-600 text-white px-4 py-2 rounded-lg font-bold border-red-800 hover:bg-red-500 text-sm flex items-center gap-2 flex-shrink-0 hidden" type="button">
+        <i data-lucide="x-circle" class="w-4 h-4"></i>
+        <span>クエストを閉じる</span>
+      </button>
     </header>
 
     <section id="aiFollowupSection" class="glass-panel rounded-xl p-4 mb-4 shadow-lg hidden space-y-2">
@@ -196,6 +200,7 @@
       }
       const backLink = document.getElementById('backLink');
       const manageBtn = document.getElementById('manageBtn');
+      const closeQuestBtn = document.getElementById('closeQuestBtn');
       const grade = params.get('grade') || gradeParam;
       const classroom = params.get('class') || classParam;
       const number = params.get('number') || numberParam;
@@ -208,6 +213,7 @@
         backLink.href = `${SCRIPT_URL}?page=quest&teacher=${encodeURIComponent(teacherCode)}&grade=${encodeURIComponent(grade)}&class=${encodeURIComponent(classroom)}&number=${encodeURIComponent(number)}`;
         backLink.innerHTML = '<i data-lucide="arrow-left" class="w-4 h-4"></i><span>クエスト画面に戻る</span>';
         manageBtn.style.display = 'none';
+        if (closeQuestBtn) closeQuestBtn.style.display = 'none';
       } else {
         if (followupSection) {
           followupSection.classList.remove('hidden');
@@ -217,6 +223,21 @@
         backLink.innerHTML = '<i data-lucide="arrow-left" class="w-4 h-4"></i><span>管理パネルに戻る</span>';
         manageBtn.href = `${SCRIPT_URL}?page=manage&teacher=${encodeURIComponent(teacherCode)}`;
         manageBtn.style.display = '';
+        if (closeQuestBtn) {
+          closeQuestBtn.style.display = taskId ? '' : 'none';
+          closeQuestBtn.addEventListener('click', () => {
+            if (!taskId) return;
+            if (confirm('このクエストを閉じますか？')) {
+              google.script.run
+                .withSuccessHandler(() => {
+                  alert('クエストを閉じました');
+                  closeQuestBtn.style.display = 'none';
+                })
+                .withFailureHandler(err => alert('閉じる際にエラーが発生しました: ' + err.message))
+                .closeTask(teacherCode, taskId);
+            }
+          });
+        }
       }
 
       if (taskId) {

--- a/src/manage.html
+++ b/src/manage.html
@@ -659,22 +659,6 @@
           return;
         }
 
-        const close = e.target.closest('.closeBtn');
-        if (close) {
-          const id = close.dataset.id;
-          if (confirm('このクエストを閉じますか？')) {
-            google.script.run
-              .withSuccessHandler(() => {
-                loadTasks();
-                updateWidgets();
-              })
-              .withFailureHandler(err => {
-                alert('閉じる際にエラーが発生しました: ' + err.message);
-              })
-              .closeTask(teacherCode, id);
-          }
-          return;
-        }
       });
 
       // 8) ウィジェット更新 (課題数・生徒数)
@@ -955,7 +939,6 @@
               <p class="text-sm text-gray-400">${x.date}</p>
             </div>
             <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2 text-xs">
-              <span class="closeBtn text-red-300 underline cursor-pointer" data-id="${x.id}" title="このクエストを閉じる">クエストを閉じる</span>
               <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
                 <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
               </button>
@@ -967,8 +950,7 @@
           card.addEventListener('click', e => {
             if (
               !e.target.closest('.deleteBtn') &&
-              !e.target.closest('.copyBtn') &&
-              !e.target.closest('.closeBtn')
+              !e.target.closest('.copyBtn')
             ) {
               location.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${x.id}`;
             }

--- a/tests/CloseTaskBonus.test.js
+++ b/tests/CloseTaskBonus.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadTask(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Task.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('closeTask sets status and awards bonus XP', () => {
+  const subsRows = [
+    ['s1','task1','', '', '', '', '', '',0,0,1,'',1],
+    ['s2','task1','', '', '', '', '', '',0,0,1,'',0]
+  ];
+  const subsSheet = {
+    getLastRow: jest.fn(() => subsRows.length + 1),
+    getRange: jest.fn(() => ({
+      getValues: () => subsRows,
+      setValues: values => {
+        for (let i=0;i<values.length;i++) {
+          subsRows[i] = values[i];
+        }
+      }
+    }))
+  };
+  const studentsData = [
+    ['StudentID','Grade','Class','Number','FirstLogin','LastLogin','LoginCount','TotalXP','Level','LastTrophyID'],
+    ['s1',1,'A',1,new Date(),new Date(),1,0,1,''],
+    ['s2',1,'A',2,new Date(),new Date(),1,0,1,'']
+  ];
+  const studentsSheet = {
+    getDataRange: jest.fn(() => ({ getValues: () => studentsData })),
+    getRange: jest.fn((row,col) => ({ setValue: val => { studentsData[row-1][col-1] = val; } }))
+  };
+  const tasksSheet = { getRange: jest.fn(() => ({ getValues: () => [['task1']], setValue: jest.fn() })), getLastRow: jest.fn(() => 2) };
+  const ss = {
+    getSheetByName: jest.fn(name => {
+      if (name === 'Tasks') return tasksSheet;
+      if (name === 'Submissions') return subsSheet;
+      if (name === 'Students') return studentsSheet;
+      return null;
+    })
+  };
+  const context = {
+    SHEET_TASKS: 'Tasks',
+    SHEET_SUBMISSIONS: 'Submissions',
+    SHEET_STUDENTS: 'Students',
+    getSpreadsheetByTeacherCode: () => ss
+  };
+  loadTask(context);
+  context.closeTask('T1','task1');
+  expect(subsRows[0][12]).toBe(1);
+  expect(subsRows[1][12]).toBe(1);
+  expect(studentsData[1][7]).toBe(5);
+  expect(studentsData[2][7]).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add bonus XP logic when closing a quest
- restore "クエストを閉じる" button on board page for teachers
- remove close quest option from manage panel
- test closing quests and awarding XP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684513cc2358832baea44c9baf351440