### PR TITLE
Fix cancel submission handling

### DIFF
--- a/src/quest.html
+++ b/src/quest.html
@@ -381,7 +381,12 @@
 
     area.innerHTML = inputHtml;
     const textarea = area.querySelector('textarea');
-    if (textarea) textarea.focus();
+    if (textarea) {
+        if (stepAnswers[questStep]) {
+            textarea.value = stepAnswers[questStep];
+        }
+        textarea.focus();
+    }
   }
 
   async function handleSend() {
@@ -424,7 +429,9 @@
     }
 
     showThinking(false);
-    renderInputForStep(q, 1);
+    if (questStep !== QuestStep.FINAL_ANSWER) {
+        renderInputForStep(q, 1);
+    }
     updateProgressBar();
     updateSendButton();
   }


### PR DESCRIPTION
## Summary
- preserve answer text when reopening quest after cancelling submission
- avoid resetting input fields when showing confirmation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68452709dca0832ba576162bdb0c0d52