### PR TITLE
Fix board duplication and load XP from history

### DIFF
--- a/src/Board.gs
+++ b/src/Board.gs
@@ -34,14 +34,26 @@ function listTaskBoard(teacherCode, taskId) {
   if (!sheet) return [];
 
   const temp = ss.insertSheet();
-  const query = `=QUERY(${SHEET_SUBMISSIONS}!A:M,"where B='${taskId}' order by E desc limit ${BOARD_FETCH_LIMIT}",0)`;
+  const query = `=QUERY(${SHEET_SUBMISSIONS}!A:M,"where B='${taskId}' order by E desc",0)`;
   temp.getRange(1, 1).setFormula(query);
   SpreadsheetApp.flush();
   const rows = Math.max(temp.getLastRow() - 1, 0);
   if (rows === 0) { ss.deleteSheet(temp); return []; }
   const data = temp.getRange(2, 1, rows, 13).getValues();
   ss.deleteSheet(temp);
-  return data.map(row => ({
+
+  const uniq = {};
+  const result = [];
+  for (let i = 0; i < data.length; i++) {
+    const r = data[i];
+    if (!uniq[r[0]]) {
+      uniq[r[0]] = true;
+      result.push(r);
+      if (result.length >= BOARD_FETCH_LIMIT) break;
+    }
+  }
+
+  return result.map(row => ({
     studentId: row[0],
     answer: row[7],
     earnedXp: row[8],

--- a/src/quest.html
+++ b/src/quest.html
@@ -245,6 +245,15 @@
       .withSuccessHandler(tasks => {
         google.script.run
           .withSuccessHandler(history => {
+            if (Array.isArray(history) && history.length > 0) {
+              const last = history[history.length - 1];
+              totalXp = Number(last[5] || 0);
+              level = Number(last[6] || 1);
+              xp = totalXp;
+              for (let l = 1; l < level; l++) { xp -= l * 100; }
+              if (xp < 0) xp = 0;
+              updateXpBar();
+            }
             renderLists(tasks || [], Array.isArray(history) ? history : []);
             hideLoadingOverlay();
             // ▼▼▼ ウェルカムメッセージ表示処理の変更 ▼▼▼


### PR DESCRIPTION
## Summary
- deduplicate answers per student in `listTaskBoard`
- initialize XP and level from the last entry in the student's history

## Testing
- `./scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68452c28a484832ba20cc5cb7c51c482