### PR TITLE
Improve performance with caching

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -6,3 +6,29 @@ function logError_(where, error) {
   if (error.stack) Logger.log(error.stack);
 }
 
+//
+// Cache helpers
+//
+function getCacheValue_(key) {
+  if (typeof CacheService === 'undefined') return null;
+  try {
+    const raw = CacheService.getScriptCache().get(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function putCacheValue_(key, value, expSec) {
+  if (typeof CacheService === 'undefined') return;
+  try {
+    CacheService.getScriptCache().put(key, JSON.stringify(value), expSec || 300);
+  } catch (e) {}
+}
+
+function removeCacheValue_(key) {
+  if (typeof CacheService === 'undefined') return;
+  try {
+    CacheService.getScriptCache().remove(key);
+  } catch (e) {}
+}


### PR DESCRIPTION
## Summary
- add caching helpers in `Utils.gs`
- cache teacher settings and class mapping
- cache task list and bust cache on edits
- handle Gemini API errors politely and fallback if CacheService unavailable

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845311f64ac832b800addca7577c3b6