### PR TITLE
Improve student history performance

### DIFF
--- a/src/Student.gs
+++ b/src/Student.gs
@@ -296,11 +296,17 @@ function updateStudentLogin(teacherCode, studentId) {
 
 function getStudentHistory(teacherCode, studentId) {
   studentId = String(studentId || '').trim();
+  const cacheKey = 'history_' + teacherCode + '_' + studentId;
+  const cached = getCacheValue_(cacheKey);
+  if (cached) return cached;
+
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) return [];
   const sheet = findStudentSheet_(ss, studentId);
   if (!sheet) return [];
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];
-  return sheet.getRange(2, 1, lastRow - 1, 9).getValues();
+  const rows = sheet.getRange(2, 1, lastRow - 1, 9).getValues();
+  putCacheValue_(cacheKey, rows, 30);
+  return rows;
 }

--- a/src/Task.gs
+++ b/src/Task.gs
@@ -301,6 +301,7 @@ function submitAnswer(teacherCode, studentId, taskId, answer,
   const submitTime = submitAt ? new Date(submitAt) : new Date();
   studentSheet.appendRow([submitTime, taskId, questionText, answer,
                           earnedXp, totalXp, level, trophies || '', attemptCount]);
+  removeCacheValue_('history_' + teacherCode + '_' + studentId);
 
   // 全体ログにも追記
   const globalAnswerSheet = ss.getSheetByName(SHEET_SUBMISSIONS);


### PR DESCRIPTION
## Summary
- cache student history rows in `getStudentHistory`
- invalidate history cache when submitting a new answer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68453ceac098832bbff0ec05bd28aca5