### PR TITLE
Improve board load speed with prefetching

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -158,6 +158,25 @@
     const version = '<?!= typeof version !== "undefined" ? version : "" ?>';
 
     let currentAnswersData = [];
+
+    function storePrefetchData(code, taskId, rows) {
+        try {
+            sessionStorage.setItem(
+                `prefetch_${code}_${taskId || 'all'}`,
+                JSON.stringify({ ts: Date.now(), data: rows })
+            );
+        } catch (e) {}
+    }
+
+    function loadPrefetchedData(code, taskId) {
+        try {
+            const raw = sessionStorage.getItem(`prefetch_${code}_${taskId || 'all'}`);
+            if (!raw) return null;
+            const obj = JSON.parse(raw);
+            if (Date.now() - obj.ts < 60000) return obj.data;
+        } catch (e) {}
+        return null;
+    }
     
     // Particle effect
     const canvas = document.getElementById('particleCanvas');
@@ -205,6 +224,13 @@
 
         debug('🔄 ページ読み込み完了');
         debug(`▶ teacherCode="${teacherCode}", taskId="${taskId || ''}"`);
+
+        const prefetched = loadPrefetchedData(teacherCode, taskId);
+        if (prefetched) {
+            debug('prefetched data found');
+            currentAnswersData = prefetched;
+            renderBoard(prefetched);
+        }
 
         if (!teacherCode) {
             alert('不正なアクセスです。');
@@ -287,6 +313,7 @@
             debug(`データ取得成功: ${rows.length}件`);
             currentAnswersData = rows;
             renderBoard(rows);
+            storePrefetchData(teacherParam, taskId, rows);
         }).withFailureHandler(err => debug(`データ取得エラー: ${err.message}`))[func](teacherParam, taskId);
     }
     

--- a/src/manage.html
+++ b/src/manage.html
@@ -348,6 +348,29 @@
       debugContentElem.scrollTop = debugContentElem.scrollHeight;
     }
 
+    function storePrefetchData(code, taskId, rows) {
+      try {
+        sessionStorage.setItem(
+          `prefetch_${code}_${taskId || 'all'}`,
+          JSON.stringify({ ts: Date.now(), data: rows })
+        );
+      } catch (e) {}
+    }
+
+    function prefetchBoardData(code, taskId) {
+      try {
+        const raw = sessionStorage.getItem(`prefetch_${code}_${taskId || 'all'}`);
+        if (raw) {
+          const obj = JSON.parse(raw);
+          if (Date.now() - obj.ts < 60000) return;
+        }
+      } catch (e) {}
+      const fn = taskId ? 'listTaskBoard' : 'listBoard';
+      google.script.run.withSuccessHandler(rows => {
+        storePrefetchData(code, taskId, rows);
+      })[fn](code, taskId);
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       debugContentElem = document.getElementById('debugContent');
       const debugPanel = document.getElementById('debugPanel');
@@ -947,6 +970,7 @@
               </button>
             </div>
           `;
+          card.addEventListener('mouseenter', () => prefetchBoardData(teacherCode, x.id));
           card.addEventListener('click', e => {
             if (
               !e.target.closest('.deleteBtn') &&
@@ -957,6 +981,8 @@
           });
           container.appendChild(card);
         });
+
+        if (rows[0]) prefetchBoardData(teacherCode, rows[0].id);
 
         // アイコン描画
         renderIcons(document);

--- a/src/quest.html
+++ b/src/quest.html
@@ -212,6 +212,29 @@
   }
   function renderIcons() { if (window.lucide) { window.lucide.createIcons(); } }
 
+  function storePrefetchData(code, taskId, rows) {
+    try {
+      sessionStorage.setItem(
+        `prefetch_${code}_${taskId || 'all'}`,
+        JSON.stringify({ ts: Date.now(), data: rows })
+      );
+    } catch (e) {}
+  }
+
+  function prefetchBoardData(code, taskId) {
+    try {
+      const raw = sessionStorage.getItem(`prefetch_${code}_${taskId || 'all'}`);
+      if (raw) {
+        const obj = JSON.parse(raw);
+        if (Date.now() - obj.ts < 60000) return;
+      }
+    } catch (e) {}
+    const fn = taskId ? 'listTaskBoard' : 'listBoard';
+    google.script.run.withSuccessHandler(rows => {
+      storePrefetchData(code, taskId, rows);
+    })[fn](code, taskId);
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     if (!teacherCode || !grade || !classroom || !number) {
         document.getElementById('loadingOverlay').textContent = '不正なアクセスです。';
@@ -335,6 +358,7 @@
     const firstTask = unanswered[0] || answered[0];
     const link = document.getElementById('viewAnswersBtn');
     link.href = firstTask ? `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${firstTask.id}&grade=${grade}&class=${classroom}&number=${number}` : '#';
+    if (firstTask) prefetchBoardData(teacherCode, firstTask.id);
   }
 
   async function openTask(task, history) {
@@ -366,6 +390,7 @@
 
     const viewAnswersBtn = document.getElementById('viewAnswersBtn');
     viewAnswersBtn.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${task.id}&grade=${grade}&class=${classroom}&number=${number}`;
+    prefetchBoardData(teacherCode, task.id);
   }
 
   function renderInputForStep(q, attempt) {


### PR DESCRIPTION
## Summary
- add sessionStorage helpers to store prefetched board data
- load prefetched data when opening board page
- prefetch latest board info on manage panel and quest page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845402be4f0832b9ed8799ba014744b