### PR TITLE
Improve debug panel toggle

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -73,8 +73,8 @@
       text-overflow: ellipsis;
       height: 96px; 
     }
-     #debugPanel {
-      position: fixed; bottom: 1rem; left: 1rem; width: 320px;
+    #debugPanel {
+      position: fixed; bottom: 3rem; right: 1rem; width: 320px;
       max-height: 200px; background: rgba(31, 41, 55, 0.9);
       border: 1px solid #4b5563; border-radius: 0.5rem;
       overflow-y: auto; padding: 0.75rem; font-size: 0.75rem;
@@ -85,6 +85,7 @@
       display: flex; justify-content: space-between; align-items: center;
     }
     #debugClose { cursor: pointer; color: #f87171; }
+    #versionInfo { cursor: pointer; }
   </style>
 </head>
 <body class="p-4 md:p-6">
@@ -214,9 +215,10 @@
     document.addEventListener('DOMContentLoaded', () => {
         debugContentElem = document.getElementById('debugContent');
         const debugPanel = document.getElementById('debugPanel');
-        debugPanel.classList.remove('hidden');
         document.getElementById('debugClose').addEventListener('click', () => debugPanel.classList.add('hidden'));
-        document.getElementById('versionInfo').textContent = version;
+        const versionEl = document.getElementById('versionInfo');
+        versionEl.textContent = version;
+        versionEl.addEventListener('click', () => debugPanel.classList.toggle('hidden'));
 
         const params = new URLSearchParams(location.search);
         let teacherCode = params.get('teacher') || teacherParam;

--- a/src/login.html
+++ b/src/login.html
@@ -87,8 +87,8 @@
     /* debug panel styles from original */
     #debugPanel {
       position: fixed;
-      bottom: 1rem;
-      left: 1rem;
+      bottom: 3rem;
+      right: 1rem;
       width: 320px;
       max-height: 200px;
       background: rgba(31, 41, 55, 0.9);
@@ -113,6 +113,7 @@
       cursor: pointer;
       color: #f87171;
     }
+    #versionInfo { cursor: pointer; }
     #loginBox {
       position: relative;
     }
@@ -275,7 +276,10 @@
     document.addEventListener('DOMContentLoaded', () => {
       debugContentElem = document.getElementById('debugContent');
       const debugPanel = document.getElementById('debugPanel');
-      debugPanel.classList.remove('hidden');
+      const versionEl = document.getElementById('versionInfo');
+      const debugCloseBtn = document.getElementById('debugClose');
+      versionEl.addEventListener('click', () => debugPanel.classList.toggle('hidden'));
+      debugCloseBtn.addEventListener('click', () => debugPanel.classList.add('hidden'));
 
       debug('🔄 ページ読み込み完了');
       gsap.from('#loginBox', { scale: 0, duration: 0.6, ease: 'back' });
@@ -489,7 +493,7 @@
   </script>
 
   <!-- デバッグパネル（左下） -->
-  <div id="debugPanel">
+  <div id="debugPanel" class="hidden">
     <div id="debugPanelHeader">
       <span>デバッグログ</span>
       <span id="debugClose">✕</span>

--- a/src/manage.html
+++ b/src/manage.html
@@ -72,8 +72,8 @@
         /* デバッグパネル */
         #debugPanel {
             position: fixed;
-            bottom: 1rem;
-            left: 1rem;
+            bottom: 3rem;
+            right: 1rem;
             width: 320px;
             max-height: 200px;
             background: rgba(31, 41, 55, 0.9);
@@ -98,6 +98,7 @@
             cursor: pointer;
             color: #f87171;
         }
+        #versionInfo { cursor: pointer; }
     </style>
 </head>
 <body class="text-gray-200 min-h-screen p-4 pixel-bg">
@@ -374,7 +375,10 @@
     document.addEventListener('DOMContentLoaded', () => {
       debugContentElem = document.getElementById('debugContent');
       const debugPanel = document.getElementById('debugPanel');
-      debugPanel.classList.remove('hidden');
+      const versionEl = document.getElementById('versionInfo');
+      const debugCloseBtn = document.getElementById('debugClose');
+      versionEl.addEventListener('click', () => debugPanel.classList.toggle('hidden'));
+      debugCloseBtn.addEventListener('click', () => debugPanel.classList.add('hidden'));
 
       debug('🔄 ページ読み込み完了');
       debug(`▶ teacherCode="${teacherCode}"`);
@@ -1137,7 +1141,7 @@
   </script>
 
   <!-- デバッグパネル（左下） -->
-  <div id="debugPanel">
+  <div id="debugPanel" class="hidden">
     <div id="debugPanelHeader">
       <span>デバッグログ</span>
       <span id="debugClose">✕</span>


### PR DESCRIPTION
## Summary
- toggle debug panel when clicking the version label
- move panel to bottom-right with a small offset
- hide panel by default on login and manage pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455de752c8832bad331d9b9ffd24fe