### PR TITLE
Improve performance instrumentation

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -18,6 +18,7 @@ const SQ_VERSION           = 'v1.0.136';
  * doGet(e): テンプレートにパラメータを埋め込んで返す
  */
 function doGet(e) {
+  console.time('doGet');
   const page = (e && e.parameter && e.parameter.page) ? e.parameter.page : 'login';
   const template = HtmlService.createTemplateFromFile(page);
   template.scriptUrl   = ScriptApp.getService().getUrl();
@@ -26,10 +27,12 @@ function doGet(e) {
   template.classroom   = (e && e.parameter && e.parameter['class'])  ? e.parameter['class']  : '';
   template.number      = (e && e.parameter && e.parameter.number)    ? e.parameter.number    : '';
   template.version     = getSqVersion();
-  return template
+  const result = template
     .evaluate()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
     .setTitle('StudyQuest');
+  console.timeEnd('doGet');
+  return result;
 }
 
 /**

--- a/src/Student.gs
+++ b/src/Student.gs
@@ -310,6 +310,7 @@ function updateStudentLogin(teacherCode, studentId) {
 }
 
 function getStudentHistory(teacherCode, studentId) {
+  console.time('getStudentHistory');
   studentId = String(studentId || '').trim();
   const cacheKey = 'history_' + teacherCode + '_' + studentId;
   const cached = getCacheValue_(cacheKey);
@@ -323,5 +324,6 @@ function getStudentHistory(teacherCode, studentId) {
   if (lastRow < 2) return [];
   const rows = sheet.getRange(2, 1, lastRow - 1, 9).getValues();
   putCacheValue_(cacheKey, rows, 30);
+  console.timeEnd('getStudentHistory');
   return rows;
 }

--- a/src/Task.gs
+++ b/src/Task.gs
@@ -49,6 +49,7 @@ function createTask(teacherCode, payloadAsJson, selfEval, persona) {
  * 課題一覧を最新→過去の順で返す
  */
 function listTasks(teacherCode) {
+  console.time('listTasks');
   const cacheKey = 'tasks_' + teacherCode;
   const cached = getCacheValue_(cacheKey);
   if (cached) return cached;
@@ -72,6 +73,7 @@ function listTasks(teacherCode) {
     closed: String(row[6] || '').toLowerCase() === 'closed'
   }));
   putCacheValue_(cacheKey, result, 300);
+  console.timeEnd('listTasks');
   return result;
 }
 

--- a/src/board.html
+++ b/src/board.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Inter:wght@400;700&display=swap" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
   <script>
     // Lucide Iconsの動的読み込み
     fetch('https://cdn.jsdelivr.net/npm/lucide@latest/dist/umd/lucide.js')

--- a/src/login.html
+++ b/src/login.html
@@ -11,13 +11,13 @@
   <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Inter:wght@400;700&display=swap" rel="stylesheet">
 
   <!-- Tailwind CSS -->
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
 
   <!-- Lucide Icons -->
-  <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.395.0/dist/lucide.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.395.0/dist/lucide.min.js" defer></script>
 
   <!-- GSAP -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
 
   <style>
     body {

--- a/src/manage.html
+++ b/src/manage.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Inter:wght@400;700&display=swap" rel="stylesheet">
 
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.395.0/dist/lucide.min.js"></script>
+    <script src="https://cdn.tailwindcss.com" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.395.0/dist/lucide.min.js" defer></script>
 
     <style>
         body {
@@ -319,7 +319,7 @@
     window.teacherCode = '<?!= teacher ?>';
   </script>
 
-<script src="https://cdn.jsdelivr.net/npm/lucide@0.259.0/dist/umd/lucide.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/lucide@0.259.0/dist/umd/lucide.min.js" defer></script>
 
   <script>
   <?!= include('shared/escapeHtml'); ?>

--- a/src/quest.html
+++ b/src/quest.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Inter:wght@400;700&display=swap" rel="stylesheet" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+  <script src="https://cdn.tailwindcss.com" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
   <script>
     // Lucide Iconsの動的読み込み
     fetch('https://cdn.jsdelivr.net/npm/lucide@latest/dist/umd/lucide.js')


### PR DESCRIPTION
## Summary
- add `console.time`/`console.timeEnd` for `doGet`, `listTasks`, `getStudentHistory`
- load external scripts with `defer` to avoid render blocking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455f19ea64832ba363ce711539fffe