### PR TITLE
Optimize performance and DOM updates

### DIFF
--- a/src/Student.gs
+++ b/src/Student.gs
@@ -112,6 +112,7 @@ function findStudentSheet_(ss, studentId) {
  * ・課題一覧からすべてのタスクをインポート
  */
 function initStudent(teacherCode, grade, classroom, number) {
+  console.time('initStudent');
   grade      = String(grade).trim();
   classroom  = String(classroom).trim();
   number     = String(number).trim();
@@ -277,6 +278,7 @@ function initStudent(teacherCode, grade, classroom, number) {
     }
   }
 
+  console.timeEnd('initStudent');
   return { status: 'ok' };
 }
 

--- a/src/Task.gs
+++ b/src/Task.gs
@@ -197,6 +197,7 @@ function getTask(teacherCode, taskId) {
  * 課題を完了状態としてマーク
  */
 function closeTask(teacherCode, taskId) {
+  console.time('closeTask');
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) return;
   const sheet = ss.getSheetByName(SHEET_TASKS);
@@ -226,6 +227,7 @@ function closeTask(teacherCode, taskId) {
     range.setValues(data);
     applyBonusXp_(ss, teacherCode, Object.keys(bonusMap), 5);
   }
+  console.timeEnd('closeTask');
 }
 
 function applyBonusXp_(ss, teacherCode, ids, amount) {
@@ -323,6 +325,7 @@ function submitAnswer(teacherCode, studentId, taskId, answer,
                       earnedXp, totalXp, level, trophies,
                       aiCalls, attemptCount,
                       startAt, submitAt, productUrl, qSummary, aSummary) {
+  console.time('submitAnswer');
   studentId = String(studentId || '').trim();
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) {
@@ -368,11 +371,11 @@ function submitAnswer(teacherCode, studentId, taskId, answer,
       level,
       trophies || '',
       1
-    ]);
+      ]);
   } else {
     console.warn(`「${SHEET_SUBMISSIONS}」シートが見つかりません。`);
   }
-
+  console.timeEnd('submitAnswer');
 }
 
 /**

--- a/src/quest.html
+++ b/src/quest.html
@@ -391,7 +391,11 @@
     showThinking(false);
 
     const rows = history.filter(r => r[1] === task.id);
-    rows.forEach(r => appendMsg('student', r[3]));
+    const frag = document.createDocumentFragment();
+    rows.forEach(r => frag.appendChild(appendMsg('student', r[3], true)));
+    document.getElementById('chatLog').appendChild(frag);
+    renderIcons();
+    document.getElementById('chatLog').scrollTop = document.getElementById('chatLog').scrollHeight;
     
     renderInputForStep(q, rows.length);
     updateProgressBar();
@@ -479,11 +483,12 @@
     updateSendButton();
   }
 
-  function appendMsg(type, text) {
+  function appendMsg(type, text, skipAppend) {
       const log = document.getElementById('chatLog');
       const div = document.createElement('div');
       const avatarImg = document.createElement('img');
       avatarImg.className = 'avatar';
+      avatarImg.loading = 'lazy';
       const textDiv = document.createElement('div');
       textDiv.className = 'p-3 rounded-lg max-w-[80%]';
       const p = document.createElement('p');
@@ -507,12 +512,14 @@
           textDiv.classList.add('bg-gray-700', 'rounded-bl-none', 'whitespace-pre-wrap');
       }
 
-      div.prepend(textDiv);
-      div.prepend(avatarImg);
-      log.appendChild(div);
-      renderIcons();
-      log.scrollTop = log.scrollHeight;
-      return div;
+        div.prepend(textDiv);
+        div.prepend(avatarImg);
+        if (!skipAppend) {
+            log.appendChild(div);
+            renderIcons();
+            log.scrollTop = log.scrollHeight;
+        }
+        return div;
   }
 
   function typeWriter(text, type) {


### PR DESCRIPTION
## Summary
- add console.time measurement to initStudent, submitAnswer and closeTask
- optimize chat history rendering with DocumentFragment
- lazily load avatars and allow skip-append in appendMsg

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456035e354832b99eed2f1672fa0c5