### PR TITLE
Improve rendering and add timing logs

### DIFF
--- a/src/Board.gs
+++ b/src/Board.gs
@@ -7,6 +7,7 @@ if (typeof getCacheValue_ !== 'function') {
 }
 
 function listBoard(teacherCode) {
+  console.time('listBoard');
   const cacheKey = 'board_' + teacherCode;
   const cached = getCacheValue_(cacheKey);
   if (cached) return cached;
@@ -32,6 +33,7 @@ function listBoard(teacherCode) {
     trophies: row[11]
   }));
   putCacheValue_(cacheKey, result, 30);
+  console.timeEnd('listBoard');
   return result;
 }
 
@@ -40,6 +42,7 @@ function listBoard(teacherCode) {
  * 指定課題の回答ログを新しい順に返す
  */
 function listTaskBoard(teacherCode, taskId) {
+  console.time('listTaskBoard');
   const cacheKey = 'taskBoard_' + teacherCode + '_' + taskId;
   const cached = getCacheValue_(cacheKey);
   if (cached) return cached;
@@ -78,6 +81,7 @@ function listTaskBoard(teacherCode, taskId) {
   }));
 
   putCacheValue_(cacheKey, result, 30);
+  console.timeEnd('listTaskBoard');
   return result;
 }
 
@@ -86,6 +90,7 @@ function listTaskBoard(teacherCode, taskId) {
  * 課題数・生徒数を取得
  */
 function getStatistics(teacherCode) {
+  console.time('getStatistics');
   const cacheKey = 'stats_' + teacherCode;
   const cached = getCacheValue_(cacheKey);
   if (cached) return cached;
@@ -109,5 +114,6 @@ function getStatistics(teacherCode) {
 
   const result = { taskCount, studentCount };
   putCacheValue_(cacheKey, result, 60);
+  console.timeEnd('getStatistics');
   return result;
 }

--- a/src/Task.gs
+++ b/src/Task.gs
@@ -9,6 +9,7 @@ if (typeof removeCacheValue_ !== 'function') {
 }
 
 function createTask(teacherCode, payloadAsJson, selfEval, persona) {
+  console.time('createTask');
   const ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) {
     throw new Error("課題作成失敗: 教師のスプレッドシートが見つかりません。");
@@ -42,6 +43,7 @@ function createTask(teacherCode, payloadAsJson, selfEval, persona) {
   removeCacheValue_('tasks_' + teacherCode);
   removeCacheValue_('taskmap_' + teacherCode);
   removeCacheValue_('stats_' + teacherCode);
+  console.timeEnd('createTask');
 }
 
 /**

--- a/src/manage.html
+++ b/src/manage.html
@@ -962,6 +962,7 @@
           return;
         }
 
+        let html = '';
         rows.forEach(x => {
           let data, detailHtml;
           try {
@@ -975,32 +976,32 @@
             detailHtml = `<p class="text-sm mb-1 whitespace-pre-wrap pr-10">${escapeHtml(x.q)}</p>`;
           }
 
-          const card = document.createElement('div');
-          card.className = 'bg-gray-700 p-4 rounded-2xl shadow-2xl transition-transform hover:scale-102 relative cursor-pointer';
-          card.innerHTML = `
-            ${detailHtml}
-            <div class="flex justify-between items-center mt-2 pr-8">
-              <p class="text-sm text-gray-400">${x.date}</p>
-            </div>
-            <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2 text-xs">
-              <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
-                <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
-              </button>
-              <button class="deleteBtn p-1" data-id="${x.id}" title="この課題を削除">
-                <i data-icon="Trash2" class="w-6 h-6 text-red-400"></i>
-              </button>
-            </div>
-          `;
-          card.addEventListener('mouseenter', () => prefetchBoardData(teacherCode, x.id));
+          html += `
+            <div class="task-card bg-gray-700 p-4 rounded-2xl shadow-2xl transition-transform hover:scale-102 relative cursor-pointer" data-id="${x.id}">
+              ${detailHtml}
+              <div class="flex justify-between items-center mt-2 pr-8">
+                <p class="text-sm text-gray-400">${x.date}</p>
+              </div>
+              <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2 text-xs">
+                <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
+                  <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
+                </button>
+                <button class="deleteBtn p-1" data-id="${x.id}" title="この課題を削除">
+                  <i data-icon="Trash2" class="w-6 h-6 text-red-400"></i>
+                </button>
+              </div>
+            </div>`;
+        });
+
+        container.innerHTML = html;
+        container.querySelectorAll('.task-card').forEach(card => {
+          const id = card.dataset.id;
+          card.addEventListener('mouseenter', () => prefetchBoardData(teacherCode, id));
           card.addEventListener('click', e => {
-            if (
-              !e.target.closest('.deleteBtn') &&
-              !e.target.closest('.copyBtn')
-            ) {
-              location.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${x.id}`;
+            if (!e.target.closest('.deleteBtn') && !e.target.closest('.copyBtn')) {
+              location.href = `${SCRIPT_URL}?page=board&teacher=${encodeURIComponent(teacherCode)}&task=${id}`;
             }
           });
-          container.appendChild(card);
         });
 
         if (rows[0]) prefetchBoardData(teacherCode, rows[0].id);


### PR DESCRIPTION
## Summary
- optimize task rendering in `manage.html` by building HTML in memory
- add execution timing logs to `listBoard`, `listTaskBoard`, `getStatistics` and `createTask`

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684561fde818832b967bbeb002bd2dbe