### PR TITLE
Improve performance with caching and DOM batching

### DIFF
--- a/src/login.html
+++ b/src/login.html
@@ -290,12 +290,9 @@
         history = [];
       }
       const list = document.getElementById('teacherHistory');
-      list.innerHTML = '';
-      history.forEach(code => {
-        const opt = document.createElement('option');
-        opt.value = code;
-        list.appendChild(opt);
-      });
+      let html = '';
+      history.forEach(code => { html += `<option value="${escapeHtml(code)}"></option>`; });
+      list.innerHTML = html;
       toggleTeacherMode();
       document.getElementById('teacherMode').addEventListener('change', toggleTeacherMode);
       document.getElementById('loginForm').addEventListener('submit', handleSubmit);

--- a/src/manage.html
+++ b/src/manage.html
@@ -775,11 +775,9 @@
         } catch (_) {
           hist = [];
         }
-        hist.forEach(s => {
-          const opt = document.createElement('option');
-          opt.value = s;
-          list.appendChild(opt);
-        });
+        let html = '';
+        hist.forEach(s => { html += `<option value="${escapeHtml(s)}"></option>`; });
+        list.innerHTML = html;
       }
 
       function addSubjectHistory(subj) {
@@ -838,17 +836,15 @@
           return;
         }
         wrapper.classList.remove('hidden');
-        container.innerHTML = '';
+        let html = '';
         generationHistory.forEach((historySet, index) => {
-          const historyEntry = document.createElement('div');
-          historyEntry.className = 'border-t border-gray-700 pt-2';
           const listItems = historySet.map(item => `<li>${escapeHtml(item)}</li>`).join('');
-          historyEntry.innerHTML = `
+          html = `<div class="border-t border-gray-700 pt-2">
             <p class="text-xs font-bold text-gray-500">履歴 ${index + 1}</p>
             <ul class="list-disc list-inside text-xs">${listItems}</ul>
-          `;
-          container.prepend(historyEntry);
+          </div>` + html;
         });
+        container.innerHTML = html;
       }
 
 
@@ -881,15 +877,15 @@
         if (controls) controls.innerHTML = '';
         if (choices.length === 0) choices = [''];
 
+        let html = '';
         choices.forEach((choice, index) => {
-          const div = document.createElement('div');
-          div.className = 'flex items-center gap-2';
-          div.innerHTML = `
-            <input type="text" value="${escapeHtml(choice)}" placeholder="選択肢 ${index + 1}" class="w-full p-2 bg-gray-900/80 rounded-md border border-gray-700 text-sm">
-            <button type="button" class="removeOptionBtn text-red-400 hover:text-red-300 p-1"><i data-lucide="x-circle" class="w-4 h-4"></i></button>
-          `;
-          container.appendChild(div);
+          html += `
+            <div class="flex items-center gap-2">
+              <input type="text" value="${escapeHtml(choice)}" placeholder="選択肢 ${index + 1}" class="w-full p-2 bg-gray-900/80 rounded-md border border-gray-700 text-sm">
+              <button type="button" class="removeOptionBtn text-red-400 hover:text-red-300 p-1"><i data-lucide="x-circle" class="w-4 h-4"></i></button>
+            </div>`;
         });
+        container.innerHTML = html;
 
         if (controls) {
           controls.innerHTML = `


### PR DESCRIPTION
## Summary
- cache teacher root folder ID for faster lookup
- batch update teacher history options on login page
- reduce DOM operations for subject history, generation history, and option inputs

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845773a086c832b9e3f82b3764b44bf