### PR TITLE
Prevent duplicate student registration

### DIFF
--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -79,7 +79,11 @@ function registerStudentToClass(idToken, info) {
     registration = JSON.parse(blob);
   }
   registration.registrations = registration.registrations || [];
-  registration.registrations.push({ teacherCode: info.teacherCode, studentId: info.studentId });
+  const exists = registration.registrations.some(r =>
+    r.teacherCode === info.teacherCode && r.studentId === info.studentId);
+  if (!exists) {
+    registration.registrations.push({ teacherCode: info.teacherCode, studentId: info.studentId });
+  }
 
   const blob = Utilities.newBlob(JSON.stringify(registration), 'application/json', 'registration.json');
   if (fileId) {


### PR DESCRIPTION
## Summary
- avoid duplicate registrations when registering students to a class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845815224cc832b9bc27475987a8953