### PR TITLE
Add teacher passcode logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ログインページ(`login.html`)では **Google Identity Services** を利用してIDトークンを取得します。得られたトークンは `google.script.run` を介してサーバーに送られ、次の処理を実行します。
 
 1. **verifyGoogleToken(idToken)** — `https://oauth2.googleapis.com/tokeninfo` でトークンを検証し、結果を5分間キャッシュします。【F:src/Auth.gs†L10-L27】
-2. **handleTeacherAuth(idToken)** — 教師モード時に `registration.json` を確認し、存在しなければ `initTeacher()` でフォルダとスプレッドシートを作成します。登録情報は5分間キャッシュされます。【F:src/Auth.gs†L32-L65】
+2. **handleTeacherAuth(idToken, passcode)** — 教師モード時に `registration.json` を確認し、存在しなければ `initTeacher()` でフォルダとスプレッドシートを作成します。登録情報は5分間キャッシュされます。【F:src/Auth.gs†L31-L74】
 3. **getStudentInfo(idToken)** — 生徒モードで `registration.json` を取得し、無ければ `status: 'new'` を返します。【F:src/Auth.gs†L71-L91】
 4. **registerStudentToClass(idToken, info)** — 生徒登録情報を `registration.json` に追加し、`initStudent()` を呼び出します。結果は5分間キャッシュされます。【F:src/Auth.gs†L94-L134】
 

--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -31,10 +31,19 @@ function verifyGoogleToken(idToken) {
 /**
  * Handle teacher authentication and registration.json management.
  * @param {string} idToken
+ * @param {string} passcode
  */
-function handleTeacherAuth(idToken) {
+function handleTeacherAuth(idToken, passcode) {
   console.time('handleTeacherAuth');
   const user = verifyGoogleToken(idToken);
+  const props = PropertiesService.getScriptProperties();
+  const storedPass = props.getProperty('teacherPasscode');
+  if (!storedPass) {
+    props.setProperty('teacherPasscode', passcode);
+  } else if (storedPass !== passcode) {
+    console.timeEnd('handleTeacherAuth');
+    throw new Error('Invalid passcode');
+  }
   const cacheKey = 'reg_' + user.sub;
   let registration = getCacheValue_(cacheKey);
   if (!registration) {


### PR DESCRIPTION
## Summary
- require passcode for teacher login
- store first passcode in script properties and validate on later logins
- document new parameter in README

## Testing
- `scripts/setup-codex.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845979feb70832b998ed818f68c3f67