### PR TITLE
Validate OAuth client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@
 
 ログインページ(`login.html`)では **Google Identity Services** を利用してIDトークンを取得します。得られたトークンは `google.script.run` を介してサーバーに送られ、次の処理を実行します。
 
-1. **verifyGoogleToken(idToken)** — `https://oauth2.googleapis.com/tokeninfo` でトークンを検証し、結果を5分間キャッシュします。【F:src/Auth.gs†L10-L27】
+1. **verifyGoogleToken(idToken)** — `https://oauth2.googleapis.com/tokeninfo` でトークンを検証し、結果を5分間キャッシュします。`aud` フィールドが `OAUTH_CLIENT_ID` と一致しない場合はエラーになります。【F:src/Auth.gs†L11-L38】
 2. **handleTeacherAuth(idToken, passcode)** — 教師モード時に `registration.json` を確認し、存在しなければ `initTeacher()` でフォルダとスプレッドシートを作成します。登録情報は5分間キャッシュされます。【F:src/Auth.gs†L31-L74】
 3. **getStudentInfo(idToken)** — 生徒モードで `registration.json` を取得し、無ければ `status: 'new'` を返します。【F:src/Auth.gs†L71-L91】
 4. **registerStudentToClass(idToken, info)** — 生徒登録情報を `registration.json` に追加し、`initStudent()` を呼び出します。結果は5分間キャッシュされます。【F:src/Auth.gs†L94-L134】
+
+`OAUTH_CLIENT_ID` はスクリプトプロパティに登録するか、`src/Auth.gs` の定数を書き換えて設定してください。
 
 フォームでは教師/生徒を切り替えられます。教師はチェックを入れてGoogle認証するだけで `manage.html` へ進みます。生徒は `quest.html` に遷移します。IDトークン取得処理は次の通りです。【F:src/login.html†L460-L493】
 

--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -2,6 +2,12 @@
  * Authentication helper functions using Google Identity Services.
  */
 
+// Expected OAuth client ID used to verify ID tokens
+const OAUTH_CLIENT_ID =
+  (typeof PropertiesService !== 'undefined' &&
+   PropertiesService.getScriptProperties().getProperty('OAUTH_CLIENT_ID')) ||
+  'YOUR_CLIENT_ID';
+
 /**
  * Verify ID token issued by Google Identity Services and return basic user info.
  * @param {string} idToken
@@ -22,6 +28,10 @@ function verifyGoogleToken(idToken) {
   const url = 'https://oauth2.googleapis.com/tokeninfo?id_token=' + encodeURIComponent(idToken);
   const res = UrlFetchApp.fetch(url);
   const data = JSON.parse(res.getContentText());
+  if (data.aud !== OAUTH_CLIENT_ID) {
+    console.timeEnd('verifyGoogleToken');
+    throw new Error('OAuth client ID mismatch');
+  }
   const info = { email: data.email, name: data.name || '', sub: data.sub };
   putCacheValue_(cacheKey, info, 300);
   console.timeEnd('verifyGoogleToken');


### PR DESCRIPTION
## Summary
- enforce OAuth client ID check in `verifyGoogleToken`
- mention `OAUTH_CLIENT_ID` configuration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459a17dbf4832b8489d0878c0451aa