### PR TITLE
Inject OAuth client id from script props

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 3. **getStudentInfo(idToken)** — 生徒モードで `registration.json` を取得し、無ければ `status: 'new'` を返します。【F:src/Auth.gs†L71-L91】
 4. **registerStudentToClass(idToken, info)** — 生徒登録情報を `registration.json` に追加し、`initStudent()` を呼び出します。結果は5分間キャッシュされます。【F:src/Auth.gs†L94-L134】
 
-`OAUTH_CLIENT_ID` はスクリプトプロパティに登録するか、`src/Auth.gs` の定数を書き換えて設定してください。
+`OAUTH_CLIENT_ID` はスクリプトプロパティまたは環境変数 `OAUTH_CLIENT_ID` に登録してください。ログインページでは `doGet` から埋め込まれた値を使用して Google Identity Services を初期化します。
 
 フォームでは教師/生徒を切り替えられます。教師はチェックを入れてGoogle認証するだけで `manage.html` へ進みます。生徒は `quest.html` に遷移します。IDトークン取得処理は次の通りです。【F:src/login.html†L460-L493】
 
@@ -229,7 +229,10 @@
 
 4. Drive API、Sheets APIの有効化（必要に応じて Apps Script エディタから追加）
 
-5. 教師として初回ログインした際に、README で定義されたシート構造の
+5. Apps Script の **スクリプトプロパティ** に `OAUTH_CLIENT_ID` を登録します。
+   ローカルテストを行う場合は環境変数 `OAUTH_CLIENT_ID` を設定してください。
+
+6. 教師として初回ログインした際に、README で定義されたシート構造の
    **StudyQuest_DB** スプレッドシートが自動生成されます。
    生成後は Apps Script の `initTeacher()` を呼び出して確認してください。
 

--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -3,10 +3,18 @@
  */
 
 // Expected OAuth client ID used to verify ID tokens
-const OAUTH_CLIENT_ID =
-  (typeof PropertiesService !== 'undefined' &&
-   PropertiesService.getScriptProperties().getProperty('OAUTH_CLIENT_ID')) ||
-  'YOUR_CLIENT_ID';
+function getOAuthClientId() {
+  if (typeof PropertiesService !== 'undefined') {
+    const id = PropertiesService.getScriptProperties().getProperty('OAUTH_CLIENT_ID');
+    if (id) return id;
+  }
+  if (typeof process !== 'undefined' && process.env && process.env.OAUTH_CLIENT_ID) {
+    return process.env.OAUTH_CLIENT_ID;
+  }
+  return '';
+}
+
+const OAUTH_CLIENT_ID = getOAuthClientId();
 
 /**
  * Verify ID token issued by Google Identity Services and return basic user info.
@@ -155,5 +163,11 @@ function registerStudentToClass(idToken, info) {
 
 // Export for Jest tests
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { verifyGoogleToken, handleTeacherAuth, getStudentInfo, registerStudentToClass };
+  module.exports = {
+    verifyGoogleToken,
+    handleTeacherAuth,
+    getStudentInfo,
+    registerStudentToClass,
+    getOAuthClientId
+  };
 }

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -27,6 +27,7 @@ function doGet(e) {
   template.classroom   = (e && e.parameter && e.parameter['class'])  ? e.parameter['class']  : '';
   template.number      = (e && e.parameter && e.parameter.number)    ? e.parameter.number    : '';
   template.version     = getSqVersion();
+  template.clientId    = getOAuthClientId();
   const result = template
     .evaluate()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)

--- a/src/login.html
+++ b/src/login.html
@@ -104,7 +104,7 @@
   <script>
     <?!= include('shared/escapeHtml'); ?>
     const SCRIPT_URL = '<?!= scriptUrl.replace("/dev", "/exec") ?>';
-    const CLIENT_ID = 'YOUR_CLIENT_ID'; // ここに実際のクライアントIDを設定
+    const CLIENT_ID = '<?!= clientId ?>';
     const version = '<?!= version ?>';
     const teacherParam = '<?!= teacher ?>';
     const gradeParam = '<?!= grade ?>';


### PR DESCRIPTION
## Summary
- load OAuth client ID from script properties or environment variable
- inject client ID into login page via `doGet`
- document where to configure the client ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459c663b08832b8d5b626c10173489