### PR TITLE
Fix board navigation and adjust debug panel position

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -74,7 +74,7 @@
       height: 96px; 
     }
     #debugPanel {
-      position: fixed; bottom: 3rem; right: 1rem; width: 320px;
+      position: fixed; bottom: 2.75rem; right: 0.5rem; width: 320px;
       max-height: 200px; background: rgba(31, 41, 55, 0.9);
       border: 1px solid #4b5563; border-radius: 0.5rem;
       overflow-y: auto; padding: 0.75rem; font-size: 0.75rem;

--- a/src/manage.html
+++ b/src/manage.html
@@ -72,8 +72,8 @@
         /* デバッグパネル */
         #debugPanel {
             position: fixed;
-            bottom: 3rem;
-            right: 1rem;
+            bottom: 2.75rem;
+            right: 0.5rem;
             width: 320px;
             max-height: 200px;
             background: rgba(31, 41, 55, 0.9);

--- a/src/quest.html
+++ b/src/quest.html
@@ -163,7 +163,7 @@
                 <i data-lucide="send-horizontal"></i>
                 <span>送信</span>
               </button>
-              <a id="viewAnswersBtn" class="game-btn w-full sm:w-auto bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-500 flex items-center justify-center gap-2" href="#" target="_blank">
+              <a id="viewAnswersBtn" class="game-btn w-full sm:w-auto bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-500 flex items-center justify-center gap-2" href="#">
                 <i data-lucide="users"></i>
                 <span>みんなの回答を見る</span>
               </a>


### PR DESCRIPTION
## Summary
- open the answers board from quest screen in the same tab
- place debug log panels directly above the version info for board and manage pages

## Testing
- `npm test` *(fails: dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845a18f41b0832bb557834b749d25fe