### PR TITLE
Improve responsive layout

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -110,7 +110,7 @@
         </div>
     </header>
 
-    <main id="answers" class="grid grid-cols-4 gap-4"></main>
+    <main id="answers" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"></main>
   </div>
   
   <div id="modalContainer" class="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4 hidden opacity-0 transition-opacity duration-300">

--- a/src/quest.html
+++ b/src/quest.html
@@ -105,9 +105,9 @@
       </div>
     </header>
 
-    <div class="flex-grow flex gap-4 overflow-hidden">
+    <div class="flex-grow flex flex-col md:flex-row gap-4 overflow-hidden">
       <!-- ===== サイドバー: クエストボード ===== -->
-      <aside class="w-72 flex-shrink-0 flex flex-col glass-panel rounded-xl p-4 shadow-lg">
+      <aside class="w-full md:w-72 flex-shrink-0 flex flex-col glass-panel rounded-xl p-4 shadow-lg">
         <div class="flex items-center justify-between mb-3">
             <h2 class="text-lg font-bold flex items-center gap-2">
               <i data-lucide="scroll-text" class="w-5 h-5 text-amber-400"></i>


### PR DESCRIPTION
## Summary
- improve grid layout on answer board for small screens
- stack quest page sections vertically on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68460b95ef68832bbade92b7d1ab934e