### PR TITLE
Fix login scope issue

### DIFF
--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -15,10 +15,11 @@
     "access": "ANYONE",
     "executeAs": "USER_ACCESSING"
   },
-  "oauthScopes": [
-    "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/drive.appdata",
-    "https://www.googleapis.com/auth/spreadsheets"
-  ]
-}
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/script.external_request",
+      "https://www.googleapis.com/auth/drive",
+      "https://www.googleapis.com/auth/drive.appdata",
+      "https://www.googleapis.com/auth/spreadsheets",
+      "https://www.googleapis.com/auth/userinfo.email"
+    ]
+  }


### PR DESCRIPTION
## Summary
- allow retrieving user email by adding the required Apps Script scope

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461f02dd5c832b8680f9ca9c702cac