### PR TITLE
Fix teacher code placeholder handling

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -186,7 +186,7 @@
   <script>
     const SCRIPT_URL = '<?!= scriptUrl.replace("/dev", "/exec") ?>';
     window.teacherCode = '<?!= teacher ?>';
-    if (!window.teacherCode) {
+    if (!window.teacherCode || window.teacherCode === '----') {
       const p = new URLSearchParams(window.location.search);
       window.teacherCode = p.get('teacher') || '';
     }


### PR DESCRIPTION
## Summary
- treat `'----'` teacher codes as invalid in `manage.html`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68464ec7d74c832ba3314ed18ea39bce