### PR TITLE
Implement trophy awarding logic

### DIFF
--- a/tests/Gamification.test.js
+++ b/tests/Gamification.test.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadGamification(context) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/Gamification.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+function makeSheet(data) {
+  return {
+    getLastRow: jest.fn(() => data.length),
+    getLastColumn: jest.fn(() => data[0].length),
+    getRange: jest.fn((r, c, rows, cols) => ({
+      getValues: () => {
+        const out = [];
+        for (let i = 0; i < (rows || 1); i++) {
+          const row = [];
+          for (let j = 0; j < (cols || 1); j++) {
+            row.push(data[r - 1 + i][c - 1 + j]);
+          }
+          out.push(row);
+        }
+        return out;
+      },
+      setValues: vals => {
+        for (let i = 0; i < vals.length; i++) {
+          for (let j = 0; j < vals[i].length; j++) {
+            data[r - 1 + i][c - 1 + j] = vals[i][j];
+          }
+        }
+      }
+    })),
+    appendRow: jest.fn(row => data.push(row))
+  };
+}
+
+ test('checkAndAwardTrophies awards trophies when conditions met', () => {
+  const trophies = [
+    ['TrophyID','Name','Desc','Icon','Condition'],
+    ['t1','T1','d','', JSON.stringify({ Global_TotalXP: 50 })],
+    ['t2','T2','d','', JSON.stringify({ LoginStreak: 3 })]
+  ];
+  const trophySheet = makeSheet(trophies);
+  const log = [['UserTrophyID','UserEmail','TrophyID','AwardedAt']];
+  const logSheet = makeSheet(log);
+  const users = [
+    ['Email','Name','Role','Global_TotalXP','Global_Level','Global_Coins','EquippedTitle','CreatedAt','LastGlobalLogin','LoginStreak'],
+    ['u@example.com','A','student',80,2,10,'','','',2]
+  ];
+  const userSheet = makeSheet(users);
+  const teacherDb = { getSheetByName: jest.fn(name => name === 'Trophies' ? trophySheet : null) };
+  const globalDb = { getSheetByName: jest.fn(name => {
+    if (name === 'Global_Trophies_Log') return logSheet;
+    if (name === 'Global_Users') return userSheet;
+    return null;
+  }) };
+  const context = {
+    getSpreadsheetByTeacherCode: () => teacherDb,
+    getGlobalDb_: () => globalDb,
+    Utilities: { getUuid: () => 'uid1' }
+  };
+  loadGamification(context);
+  const awarded = context.checkAndAwardTrophies('u@example.com', { teacherCode: 'T' });
+  expect(awarded).toEqual(['t1']);
+  expect(log[1][1]).toBe('u@example.com');
+  expect(log[1][2]).toBe('t1');
+});
+
+ test('checkAndAwardTrophies returns empty when none match', () => {
+  const trophies = [
+    ['TrophyID','Name','Desc','Icon','Condition'],
+    ['t1','T1','d','', JSON.stringify({ Global_TotalXP: 100 })]
+  ];
+  const trophySheet = makeSheet(trophies);
+  const log = [['UserTrophyID','UserEmail','TrophyID','AwardedAt']];
+  const logSheet = makeSheet(log);
+  const users = [
+    ['Email','Name','Role','Global_TotalXP','Global_Level','Global_Coins','EquippedTitle','CreatedAt','LastGlobalLogin','LoginStreak'],
+    ['u@example.com','A','student',80,2,10,'','','',1]
+  ];
+  const userSheet = makeSheet(users);
+  const teacherDb = { getSheetByName: jest.fn(name => name === 'Trophies' ? trophySheet : null) };
+  const globalDb = { getSheetByName: jest.fn(name => {
+    if (name === 'Global_Trophies_Log') return logSheet;
+    if (name === 'Global_Users') return userSheet;
+    return null;
+  }) };
+  const context = {
+    getSpreadsheetByTeacherCode: () => teacherDb,
+    getGlobalDb_: () => globalDb,
+    Utilities: { getUuid: () => 'uid1' }
+  };
+  loadGamification(context);
+  const awarded = context.checkAndAwardTrophies('u@example.com', { teacherCode: 'T' });
+  expect(awarded.length).toBe(0);
+  expect(log.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- implement `checkAndAwardTrophies` to evaluate trophy conditions
- log newly earned trophies to `Global_Trophies_Log`
- return awarded trophy IDs
- add unit tests for trophy awarding scenarios

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc25f0b0832ba452ead43ff3ec8e