### PR TITLE
Fix missing SHEET_TROPHIES in Teacher tests

### DIFF
--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -192,6 +192,7 @@ test('initTeacher creates Items sheet with correct header', () => {
     SHEET_STUDENTS: 'Students',
     SHEET_SUBMISSIONS: 'Submissions',
     SHEET_AI_FEEDBACK: 'AI',
+    SHEET_TROPHIES: 'Trophies',
     SHEET_ITEMS: 'Items',
     STUDENT_SHEET_PREFIX: 'stu_',
     DriveApp: {


### PR DESCRIPTION
## Summary
- add `SHEET_TROPHIES` constant to failing test context in `tests/Teacher.test.js`

## Testing
- `npm test` *(fails: SyntaxError in `tests/Gamification.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e922226c832b98e40c5853a3a245