### PR TITLE
Implement DB accessor helpers

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -32,3 +32,43 @@ function removeCacheValue_(key) {
     CacheService.getScriptCache().remove(key);
   } catch (e) {}
 }
+
+//
+// Database access helpers
+//
+function getGlobalDb_() {
+  const cacheKey = 'GLOBAL_DB';
+  const cached = typeof getCacheValue_ === 'function' ? getCacheValue_(cacheKey) : null;
+  if (cached) return cached;
+  const props = PropertiesService.getScriptProperties();
+  const propName = (typeof PROP_GLOBAL_MASTER_DB !== 'undefined') ? PROP_GLOBAL_MASTER_DB : 'Global_Master_DB';
+  const id = props.getProperty(propName);
+  if (!id) return null;
+  try {
+    const ss = SpreadsheetApp.openById(id);
+    if (typeof putCacheValue_ === 'function') putCacheValue_(cacheKey, ss, 300);
+    return ss;
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('getGlobalDb_', e);
+    return null;
+  }
+}
+
+function getTeacherDb_(teacherCode) {
+  teacherCode = String(teacherCode || '').trim();
+  if (!teacherCode) return null;
+  const cacheKey = 'teacherdb_' + teacherCode;
+  const cached = typeof getCacheValue_ === 'function' ? getCacheValue_(cacheKey) : null;
+  if (cached) return cached;
+  const props = PropertiesService.getScriptProperties();
+  const id = props.getProperty('ssId_' + teacherCode);
+  if (!id) return null;
+  try {
+    const ss = SpreadsheetApp.openById(id);
+    if (typeof putCacheValue_ === 'function') putCacheValue_(cacheKey, ss, 300);
+    return ss;
+  } catch (e) {
+    if (typeof logError_ === 'function') logError_('getTeacherDb_', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `getGlobalDb_` and `getTeacherDb_` helpers in `Utils.gs`
- add caching logic for these database accessors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f9e18168832b914386ec87024a50