### PR TITLE
Implement basic db access and auth utilities

### DIFF
--- a/src/User.gs
+++ b/src/User.gs
@@ -1,0 +1,35 @@
+function registerUsersFromCsv(teacherCode, csvData) {
+  teacherCode = String(teacherCode || '').trim();
+  if (!csvData) return { status: 'error', message: 'no_data' };
+  const teacherDb = getTeacherDb_(teacherCode);
+  const globalDb = getGlobalDb_();
+  if (!teacherDb || !globalDb) return { status: 'error', message: 'db_not_found' };
+  const userSheet = globalDb.getSheetByName('Global_Users');
+  const enrollSheet = teacherDb.getSheetByName('Enrollments');
+  if (!userSheet || !enrollSheet) return { status: 'error', message: 'missing_sheet' };
+  const rows = Utilities.parseCsv(csvData);
+  const now = new Date();
+  const existingEmails = userSheet.getRange(2,1,Math.max(0,userSheet.getLastRow()-1),1).getValues().flat().map(e=>String(e).toLowerCase());
+  const userAppend = [];
+  const enrollAppend = [];
+  let created = 0;
+  rows.forEach(r => {
+    const email = String(r[0] || '').trim();
+    if (!email) return;
+    const name = r[1] || '';
+    const grade = r[2] || '';
+    const cls = r[3] || '';
+    const number = r[4] || '';
+    if (!existingEmails.includes(email.toLowerCase())) {
+      userAppend.push([email, name, 'student', 0, 1, 0, '', now, now, 1]);
+      existingEmails.push(email.toLowerCase());
+      created++;
+    }
+    enrollAppend.push([email, 'student', grade, cls, number, now]);
+  });
+  if (userAppend.length)
+    userSheet.getRange(userSheet.getLastRow()+1,1,userAppend.length,userAppend[0].length).setValues(userAppend);
+  if (enrollAppend.length)
+    enrollSheet.getRange(enrollSheet.getLastRow()+1,1,enrollAppend.length,enrollAppend[0].length).setValues(enrollAppend);
+  return { status: 'success', created: created, enrolled: enrollAppend.length };
+}

--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -32,3 +32,46 @@ function removeCacheValue_(key) {
     CacheService.getScriptCache().remove(key);
   } catch (e) {}
 }
+
+/**
+ * getGlobalDb_(): PropertiesService からグローバルマスターDBのスプレッドシートを取得
+ * キャッシュサービスによりIDを保持する
+ */
+function getGlobalDb_() {
+  const cacheKey = 'GLOBAL_DB_ID';
+  let id = getCacheValue_(cacheKey);
+  if (!id) {
+    const props = PropertiesService.getScriptProperties();
+    id = props.getProperty(typeof PROP_GLOBAL_MASTER_DB !== 'undefined' ? PROP_GLOBAL_MASTER_DB : 'Global_Master_DB');
+    if (id) putCacheValue_(cacheKey, id, 3600);
+  }
+  if (!id) return null;
+  try {
+    return SpreadsheetApp.openById(id);
+  } catch (e) {
+    logError_('getGlobalDb_', e);
+    return null;
+  }
+}
+
+/**
+ * getTeacherDb_(teacherCode): teacherCode から教師用DBを取得
+ */
+function getTeacherDb_(teacherCode) {
+  teacherCode = String(teacherCode || '').trim();
+  if (!teacherCode) return null;
+  const cacheKey = 'TEACHER_DB_ID_' + teacherCode;
+  let id = getCacheValue_(cacheKey);
+  if (!id) {
+    const props = PropertiesService.getScriptProperties();
+    id = props.getProperty('ssId_' + teacherCode);
+    if (id) putCacheValue_(cacheKey, id, 3600);
+  }
+  if (!id) return null;
+  try {
+    return SpreadsheetApp.openById(id);
+  } catch (e) {
+    logError_('getTeacherDb_', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add utility functions to open global and teacher DB
- support teacher setup and user registration
- add Gemini API helpers for structured content generation

## Testing
- `npm install` *(fails: `ECONNRESET`)*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847030a8af4832bb42233b12976bb48