### PR TITLE
Refactor cache helpers

### DIFF
--- a/src/Board.gs
+++ b/src/Board.gs
@@ -1,11 +1,5 @@
 const BOARD_FETCH_LIMIT = 30;
 
-// Fallbacks when running in a non-GAS environment (e.g. tests)
-if (typeof getCacheValue_ !== 'function') {
-  function getCacheValue_() { return null; }
-  function putCacheValue_() {}
-}
-
 function listBoard(teacherCode) {
   console.time('listBoard');
   const cacheKey = 'board_' + teacherCode;

--- a/src/Student.gs
+++ b/src/Student.gs
@@ -3,11 +3,6 @@
 * 学年・組・番号の組み合わせから既存シートを柔軟に探索し、
 * 必要に応じて正規化した名前へリネームして返す
 */
-if (typeof getCacheValue_ !== 'function') {
-  function getCacheValue_() { return null; }
-  function putCacheValue_() {}
-  function removeCacheValue_() {}
-}
 
 function bulkAppend_(sheet, rows) {
   if (!sheet || !rows || rows.length === 0) return;

--- a/src/Task.gs
+++ b/src/Task.gs
@@ -2,11 +2,6 @@
  * createTask(teacherCode, payloadAsJson, selfEval):
  * 新しい課題を課題一覧シートに追加
  */
-if (typeof removeCacheValue_ !== 'function') {
-  function getCacheValue_() { return null; }
-  function putCacheValue_() {}
-  function removeCacheValue_() {}
-}
 
 function createTask(teacherCode, payloadAsJson, selfEval, persona) {
   console.time('createTask');

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -1,11 +1,6 @@
 /**
  * generateTeacherCode(): 6桁英数字のユニークな教師コードを生成
  */
-if (typeof getCacheValue_ !== 'function') {
-  function getCacheValue_() { return null; }
-  function putCacheValue_() {}
-  function removeCacheValue_() {}
-}
 
 const _ssCache = {};
 

--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -1,3 +1,7 @@
+if (typeof Logger === 'undefined') {
+  var Logger = { log: function() {} };
+}
+
 /**
  * logError_(where, error): 詳細なエラーログを出力
  */
@@ -9,28 +13,34 @@ function logError_(where, error) {
 //
 // Cache helpers
 //
-function getCacheValue_(key) {
-  if (typeof CacheService === 'undefined') return null;
-  try {
-    const raw = CacheService.getScriptCache().get(key);
-    return raw ? JSON.parse(raw) : null;
-  } catch (e) {
-    return null;
+if (typeof getCacheValue_ !== 'function') {
+  function getCacheValue_(key) {
+    if (typeof CacheService === 'undefined') return null;
+    try {
+      const raw = CacheService.getScriptCache().get(key);
+      return raw ? JSON.parse(raw) : null;
+    } catch (e) {
+      return null;
+    }
   }
 }
 
-function putCacheValue_(key, value, expSec) {
-  if (typeof CacheService === 'undefined') return;
-  try {
-    CacheService.getScriptCache().put(key, JSON.stringify(value), expSec || 300);
-  } catch (e) {}
+if (typeof putCacheValue_ !== 'function') {
+  function putCacheValue_(key, value, expSec) {
+    if (typeof CacheService === 'undefined') return;
+    try {
+      CacheService.getScriptCache().put(key, JSON.stringify(value), expSec || 300);
+    } catch (e) {}
+  }
 }
 
-function removeCacheValue_(key) {
-  if (typeof CacheService === 'undefined') return;
-  try {
-    CacheService.getScriptCache().remove(key);
-  } catch (e) {}
+if (typeof removeCacheValue_ !== 'function') {
+  function removeCacheValue_(key) {
+    if (typeof CacheService === 'undefined') return;
+    try {
+      CacheService.getScriptCache().remove(key);
+    } catch (e) {}
+  }
 }
 
 /**

--- a/tests/Board.test.js
+++ b/tests/Board.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadBoard(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Board.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/CloseTaskBonus.test.js
+++ b/tests/CloseTaskBonus.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadTask(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Task.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/DraftTask.test.js
+++ b/tests/DraftTask.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadTask(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Task.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/Gemini.test.js
+++ b/tests/Gemini.test.js
@@ -8,6 +8,8 @@ function loadGemini(context) {
 }
 
 function loadTeacher(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Teacher.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/Student.test.js
+++ b/tests/Student.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadStudent(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Student.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/TaskActive.test.js
+++ b/tests/TaskActive.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadTask(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Task.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadTeacher(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Teacher.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }

--- a/tests/initTeacherDrive.test.js
+++ b/tests/initTeacherDrive.test.js
@@ -3,6 +3,8 @@ const vm = require('vm');
 const path = require('path');
 
 function loadTeacher(context) {
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
   const code = fs.readFileSync(path.join(__dirname, '../src/Teacher.gs'), 'utf8');
   vm.runInNewContext(code, context);
 }


### PR DESCRIPTION
## Summary
- centralize CacheService fallback helpers in `Utils.gs`
- load `Utils.gs` in tests that rely on cache helpers
- remove duplicated helper fallbacks from source files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684705a37a48832bb192a93365937877