### PR TITLE
Fix manage task icons

### DIFF
--- a/src/manage.html
+++ b/src/manage.html
@@ -1091,13 +1091,13 @@
               </div>
               <div class="absolute top-1/2 -translate-y-1/2 right-2 flex flex-col items-center gap-2 text-xs">
                 <button class="copyBtn p-1" data-id="${x.id}" title="この課題を複製">
-                  <i data-icon="Copy" class="w-6 h-6 text-indigo-300"></i>
+                  <i data-lucide="Copy" class="w-6 h-6 text-indigo-300"></i>
                 </button>
                 <button class="deleteBtn p-1" data-id="${x.id}" title="この課題を削除">
-                  <i data-icon="Trash2" class="w-6 h-6 text-red-400"></i>
+                  <i data-lucide="Trash2" class="w-6 h-6 text-red-400"></i>
                 </button>
                 <button class="closeBtn p-1" data-id="${x.id}" title="この課題を終了">
-                  <i data-icon="Archive" class="w-6 h-6 text-green-400"></i>
+                  <i data-lucide="Archive" class="w-6 h-6 text-green-400"></i>
                 </button>
               </div>
             </div>`;


### PR DESCRIPTION
## Summary
- use `data-lucide` for task action icons

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684763a46008832bb4d05f954d450fdd