### PR TITLE
Implement teacher setup login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,16 @@ graph TD
 
 * **教師の場合**
 
-  * `google.script.run.loginAsTeacher()` を実行
-  * 認証成功後、URLパラメータに `teacherCode` を付与して `manage.html` へ遷移
+  * `google.script.run.handleTeacherLogin()` を実行
+  * 返却値 `status` が `ok` なら `manage.html?teacher=<teacherCode>` へ遷移
+  * `status` が `new_teacher_prompt_key` のときは秘密キー入力フォームを表示
 
 * **生徒の場合**
 
   * `google.script.run.loginAsStudent()` を実行
-  * 【変更点】 認証成功後、在籍クラス数に関わらず必ず `class-select.html` へ遷移
-  * 在籍クラスがない場合は `login.html` に留まり、エラーメッセージを表示
+  * 在籍クラス数が 1 なら `quest.html?teacher=<teacherCode>` へ直接遷移
+  * 2 以上なら `class-select.html` へ遷移（リストは `sessionStorage` に保存）
+  * 0 の場合はエラーメッセージを表示
 
 #### 3.2. 生徒ハブ画面からの遷移 (`class-select.html`)
 

--- a/src/login.html
+++ b/src/login.html
@@ -28,9 +28,15 @@
 <body class="bg-gray-900 text-gray-200 flex items-center justify-center min-h-screen" style="font-family:'DotGothic16',sans-serif;">
   <main class="space-y-4 text-center">
     <h1 class="text-3xl font-bold tracking-widest">StudyQuest</h1>
-    <input id="teacher-code-input" type="text" placeholder="教師コード" class="w-full p-2 rounded bg-gray-800 border border-gray-600 focus:outline-none" />
     <button id="teacher-login-btn" class="game-btn bg-purple-600 text-white px-4 py-2 rounded-lg font-bold border-b-4 border-purple-800 hover:bg-purple-500">教師としてログイン</button>
     <button id="student-login-btn" class="game-btn bg-cyan-600 text-white px-4 py-2 rounded-lg font-bold border-b-4 border-cyan-800 hover:bg-cyan-500">生徒としてログイン</button>
+    <form id="teacher-secret-form" class="space-y-2" style="display:none;">
+      <input id="secret-key-input" type="password" placeholder="共通秘密キーを入力" class="w-full p-2 rounded bg-gray-800 border border-gray-600 focus:outline-none" />
+      <div class="flex gap-2 justify-center">
+        <button id="secret-key-submit-btn" type="submit" class="game-btn bg-green-600 text-white px-4 py-2 rounded-lg font-bold border-b-4 border-green-800 hover:bg-green-500 flex-1">セットアップ実行</button>
+        <button id="back-to-login-btn" type="button" class="game-btn bg-gray-600 text-white px-4 py-2 rounded-lg font-bold border-b-4 border-gray-800 hover:bg-gray-500 flex-1">戻る</button>
+      </div>
+    </form>
   </main>
 
   <div id="errorModal" class="hidden fixed inset-0 bg-black/70 flex items-center justify-center z-50">
@@ -44,34 +50,66 @@
   <script>
     const SCRIPT_URL = '<?!= scriptUrl.replace("/dev","/exec") ?>';
 
-    document.getElementById('teacher-login-btn').addEventListener('click', () => {
+    const teacherBtn = document.getElementById('teacher-login-btn');
+    const studentBtn = document.getElementById('student-login-btn');
+    const secretForm = document.getElementById('teacher-secret-form');
+
+    teacherBtn.addEventListener('click', () => {
       showLoadingOverlay();
       google.script.run
-        .withSuccessHandler(onTeacherLoginSuccess)
+        .withSuccessHandler(onTeacherLoginResponse)
         .withFailureHandler(onLoginFailure)
-        .loginAsTeacher();
+        .handleTeacherLogin();
     });
 
-    document.getElementById('student-login-btn').addEventListener('click', () => {
+    studentBtn.addEventListener('click', () => {
       showLoadingOverlay();
-      const code = document.getElementById('teacher-code-input').value.trim();
-      if (!code) {
-        hideLoadingOverlay();
-        showError('教師コードを入力してください');
-        return;
-      }
       google.script.run
         .withSuccessHandler(onStudentLoginSuccess)
         .withFailureHandler(onLoginFailure)
-        .loginAsStudent(code);
+        .loginAsStudent();
     });
 
-    function onTeacherLoginSuccess(res) {
+    secretForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const key = document.getElementById('secret-key-input').value.trim();
+      if (!key) return;
+      showLoadingOverlay();
+      google.script.run
+        .withSuccessHandler(onSetupSuccess)
+        .withFailureHandler(onLoginFailure)
+        .setupInitialTeacher(key);
+    });
+
+    document.getElementById('back-to-login-btn').addEventListener('click', () => {
+      secretForm.style.display = 'none';
+      teacherBtn.style.display = '';
+      studentBtn.style.display = '';
+    });
+
+    function onTeacherLoginResponse(res) {
       hideLoadingOverlay();
-      if (res && res.teacherCode) {
+      if (!res || !res.status) { showError('エラーが発生しました'); return; }
+      switch(res.status) {
+        case 'ok':
+          window.top.location.href = `${SCRIPT_URL}?page=manage&teacher=${encodeURIComponent(res.teacherCode)}`;
+          break;
+        case 'new_teacher_prompt_key':
+          teacherBtn.style.display = 'none';
+          studentBtn.style.display = 'none';
+          secretForm.style.display = '';
+          break;
+        default:
+          showError('ログインに失敗しました。');
+      }
+    }
+
+    function onSetupSuccess(res) {
+      hideLoadingOverlay();
+      if (res && res.status === 'ok') {
         window.top.location.href = `${SCRIPT_URL}?page=manage&teacher=${encodeURIComponent(res.teacherCode)}`;
       } else {
-        showError('ログインに失敗しました。');
+        showError('セットアップに失敗しました');
       }
     }
 


### PR DESCRIPTION
## Summary
- update login page to handle teacher setup with secret key
- support optional loginAsStudent flow for multi-class handling
- introduce handleTeacherLogin backend method
- document new login flow
- test coverage for new backend logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476c422224832ba2ed98775673999b