### PR TITLE
Fix initial teacher setup to use script property

### DIFF
--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -1,10 +1,10 @@
-var INITIAL_TEACHER_SECRET = "changeme";
 function setupInitialTeacher(secretKey) {
-  if (secretKey !== INITIAL_TEACHER_SECRET) {
+  const props = PropertiesService.getScriptProperties();
+  const stored = props.getProperty('teacherPasscode');
+  if (!stored || secretKey !== stored) {
     return { status: "error", message: "invalid_key" };
   }
   const email = Session.getEffectiveUser().getEmail();
-  const props = PropertiesService.getScriptProperties();
   if (props.getProperty("teacherCode_" + email)) {
     return { status: "error", message: "already_exists" };
   }

--- a/tests/Auth.test.js
+++ b/tests/Auth.test.js
@@ -33,7 +33,7 @@ test('loginAsTeacher returns not_found when missing', () => {
 });
 
 test('handleTeacherLogin differentiates new teacher', () => {
-  const props = {};
+  const props = { teacherPasscode: 'changeme' };
   const context = {
     PropertiesService: { getScriptProperties: () => ({ getProperty: k => props[k] }) },
     Session: { getEffectiveUser: () => ({ getEmail: () => 'new@example.com' }) },
@@ -108,7 +108,7 @@ test('loginAsStudent without teacherCode lists classes', () => {
 });
 
 test('setupInitialTeacher creates resources and stores ids', () => {
-  const props = {};
+  const props = { teacherPasscode: 'changeme' };
   const folder = { getId: jest.fn(() => 'fid') };
   const moveTarget = { moveTo: jest.fn() };
   const settingsSheet = { appendRow: jest.fn() };
@@ -139,7 +139,7 @@ test('setupInitialTeacher creates resources and stores ids', () => {
 });
 
 test('setupInitialTeacher validates secret and duplication', () => {
-  const props = { 'teacherCode_teacher@example.com': 'EXIST' };
+  const props = { 'teacherCode_teacher@example.com': 'EXIST', teacherPasscode: 'changeme' };
   const context = {
     PropertiesService: { getScriptProperties: () => ({
       getProperty: k => props[k],


### PR DESCRIPTION
## Summary
- read `teacherPasscode` script property in `setupInitialTeacher`
- update Auth tests with the passcode property

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684775f00d40832b8a0ed28670bbd55d