### PR TITLE
Enable student template CSV download

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -26,6 +26,14 @@ const SHEET_GLOBAL_ITEMS        = 'Global_Items_Inventory';
  */
 function doGet(e) {
   console.time('doGet');
+  if (e && e.parameter && e.parameter.download === 'student_template.csv') {
+    const csv = getStudentTemplateCsv();
+    console.timeEnd('doGet');
+    return ContentService
+      .createTextOutput(csv)
+      .downloadAsFile('student_template.csv')
+      .setMimeType(ContentService.MimeType.CSV);
+  }
   const page = (e && e.parameter && e.parameter.page) ? e.parameter.page : 'login';
   const template = HtmlService.createTemplateFromFile(page);
   template.scriptUrl   = ScriptApp.getService().getUrl();
@@ -64,7 +72,14 @@ function getCurrentUser() {
   return { email: email };
 }
 
+/**
+ * CSVテンプレート文字列を返す
+ */
+function getStudentTemplateCsv() {
+  return 'Email,Name,Grade,Class,Number\n';
+}
+
 // Export for testing in Node.js environment
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { getSqVersion };
+  module.exports = { getSqVersion, getStudentTemplateCsv };
 }

--- a/src/manage.html
+++ b/src/manage.html
@@ -134,7 +134,7 @@
         <div id="csv-upload-modal" class="fixed inset-0 bg-black/70 flex items-center justify-center hidden z-50">
             <div class="bg-gray-800 p-6 rounded-xl space-y-4 w-80 modal-content">
                 <input type="file" id="csv-file-input" accept=".csv" class="w-full text-sm text-gray-200" />
-                <a href="/path/to/template.csv" download="student_template.csv" id="download-template-btn" class="text-blue-400 underline text-sm">テンプレートをダウンロード</a>
+                <a href="<?!= scriptUrl.replace('/dev','/exec') ?>?download=student_template.csv" download="student_template.csv" id="download-template-btn" class="text-blue-400 underline text-sm">テンプレートをダウンロード</a>
                 <div class="flex justify-end gap-2">
                     <button type="button" id="close-csv-modal" class="px-3 py-1 bg-gray-600 rounded">閉じる</button>
                     <button id="upload-csv-btn" class="px-3 py-1 bg-pink-600 rounded">アップロード</button>

--- a/tests/Code.test.js
+++ b/tests/Code.test.js
@@ -1,5 +1,9 @@
-const { getSqVersion } = require('../src/Code.gs');
+const { getSqVersion, getStudentTemplateCsv } = require('../src/Code.gs');
 
 test('getSqVersion returns correct version', () => {
   expect(getSqVersion()).toBe('v1.0.191');
+});
+
+test('getStudentTemplateCsv returns header row', () => {
+  expect(getStudentTemplateCsv()).toBe('Email,Name,Grade,Class,Number\n');
 });


### PR DESCRIPTION
## Summary
- add function `getStudentTemplateCsv` and expose it for tests
- return the CSV from `doGet` when `download=student_template.csv`
- update manage page link to download the template
- test the new helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847808275f4832b812b38a8eb83a1d2