### PR TITLE
Enable student template CSV download

### DIFF
--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -47,6 +47,13 @@ function setupInitialTeacher(secretKey) {
   const ss = SpreadsheetApp.create('StudyQuest_DB_' + teacherCode);
   DriveApp.getFileById(ss.getId()).moveTo(folder);
 
+  // create student CSV template in the teacher folder
+  try {
+    if (typeof createStudentTemplateFile_ === 'function') {
+      createStudentTemplateFile_(folder, teacherCode);
+    }
+  } catch (_) {}
+
   // Step4: create sheets with headers
   const sheetDefs = [
     { name: 'Enrollments', headers: ['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt'] },

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -26,6 +26,26 @@ const SHEET_GLOBAL_ITEMS        = 'Global_Items_Inventory';
  */
 function doGet(e) {
   console.time('doGet');
+  if (e && e.parameter && e.parameter.download === 'student_template.csv') {
+    const code = e.parameter.teacher || '';
+    let csv = getStudentTemplateCsv();
+    try {
+      const props = PropertiesService.getScriptProperties();
+      const fid = props.getProperty(code);
+      if (fid) {
+        const folder = DriveApp.getFolderById(fid);
+        const files = folder.getFilesByName('student_template.csv');
+        if (files.hasNext()) {
+          csv = files.next().getBlob().getDataAsString();
+        }
+      }
+    } catch (_) {}
+    console.timeEnd('doGet');
+    return ContentService
+      .createTextOutput(csv)
+      .downloadAsFile('student_template.csv')
+      .setMimeType(ContentService.MimeType.CSV);
+  }
   const page = (e && e.parameter && e.parameter.page) ? e.parameter.page : 'login';
   const template = HtmlService.createTemplateFromFile(page);
   template.scriptUrl   = ScriptApp.getService().getUrl();

--- a/src/StudentCsv.gs
+++ b/src/StudentCsv.gs
@@ -1,0 +1,34 @@
+/**
+ * Student CSV template utilities
+ */
+
+/**
+ * Returns the header row for the student CSV template.
+ * @return {string} CSV header row
+ */
+function getStudentTemplateCsv() {
+  return 'Email,Name,Grade,Class,Number\n';
+}
+
+/**
+ * Creates the student_template.csv file in the given folder and
+ * stores its file ID using the teacher code.
+ * @param {Folder} folder Google Drive folder
+ * @param {string} teacherCode teacher code used for property key
+ * @return {string|null} Created file ID or null on failure
+ */
+function createStudentTemplateFile_(folder, teacherCode) {
+  try {
+    const csv = getStudentTemplateCsv();
+    const file = folder.createFile('student_template.csv', csv, MimeType.CSV);
+    const props = PropertiesService.getScriptProperties();
+    props.setProperty('templateCsv_' + teacherCode, file.getId());
+    return file.getId();
+  } catch (e) {
+    return null;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { getStudentTemplateCsv, createStudentTemplateFile_ };
+}

--- a/src/manage.html
+++ b/src/manage.html
@@ -134,7 +134,7 @@
         <div id="csv-upload-modal" class="fixed inset-0 bg-black/70 flex items-center justify-center hidden z-50">
             <div class="bg-gray-800 p-6 rounded-xl space-y-4 w-80 modal-content">
                 <input type="file" id="csv-file-input" accept=".csv" class="w-full text-sm text-gray-200" />
-                <a href="/path/to/template.csv" download="student_template.csv" id="download-template-btn" class="text-blue-400 underline text-sm">テンプレートをダウンロード</a>
+                <a href="<?!= scriptUrl.replace('/dev','/exec') ?>?download=student_template.csv&teacher=<?!= teacher ?>" download="student_template.csv" id="download-template-btn" class="text-blue-400 underline text-sm">テンプレートをダウンロード</a>
                 <div class="flex justify-end gap-2">
                     <button type="button" id="close-csv-modal" class="px-3 py-1 bg-gray-600 rounded">閉じる</button>
                     <button id="upload-csv-btn" class="px-3 py-1 bg-pink-600 rounded">アップロード</button>

--- a/tests/Code.test.js
+++ b/tests/Code.test.js
@@ -1,5 +1,10 @@
 const { getSqVersion } = require('../src/Code.gs');
+const { getStudentTemplateCsv } = require('../src/StudentCsv.gs');
 
 test('getSqVersion returns correct version', () => {
   expect(getSqVersion()).toBe('v1.0.191');
+});
+
+test('getStudentTemplateCsv returns header row', () => {
+  expect(getStudentTemplateCsv()).toBe('Email,Name,Grade,Class,Number\n');
 });


### PR DESCRIPTION
## Summary
- create `StudentCsv.gs` for generating template CSV files
- call new helper from `setupInitialTeacher`
- export CSV helpers for testing
- update tests to load the new module

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847808275f4832b812b38a8eb83a1d2