### PR TITLE
Fix globalDb caching bug

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -43,56 +43,22 @@ if (typeof removeCacheValue_ !== 'function') {
   }
 }
 
-/**
- * getGlobalDb_(): PropertiesService からグローバルマスターDBのスプレッドシートを取得
- * キャッシュサービスによりIDを保持する
- */
-function getGlobalDb_() {
-  const cacheKey = 'GLOBAL_DB_ID';
-  let id = getCacheValue_(cacheKey);
-  if (!id) {
-    const props = PropertiesService.getScriptProperties();
-    id = props.getProperty(typeof PROP_GLOBAL_MASTER_DB !== 'undefined' ? PROP_GLOBAL_MASTER_DB : 'Global_Master_DB');
-    if (id) putCacheValue_(cacheKey, id, 3600);
-  }
-  if (!id) return null;
-  try {
-    return SpreadsheetApp.openById(id);
-  } catch (e) {
-    logError_('getGlobalDb_', e);
-    return null;
-  }
-}
-
-/**
- * getTeacherDb_(teacherCode): teacherCode から教師用DBを取得
- */
-function getTeacherDb_(teacherCode) {
-  teacherCode = String(teacherCode || '').trim();
-  if (!teacherCode) return null;
-  const cacheKey = 'TEACHER_DB_ID_' + teacherCode;
-  let id = getCacheValue_(cacheKey);
-  if (!id) {
-    const props = PropertiesService.getScriptProperties();
-    id = props.getProperty('ssId_' + teacherCode);
-    if (id) putCacheValue_(cacheKey, id, 3600);
-  }
-  if (!id) return null;
-  try {
-    return SpreadsheetApp.openById(id);
-  } catch (e) {
-    logError_('getTeacherDb_', e);
-    return null;
-  }
-}
-
 //
 // Database access helpers
 //
 function getGlobalDb_() {
   const cacheKey = 'GLOBAL_DB';
   const cached = typeof getCacheValue_ === 'function' ? getCacheValue_(cacheKey) : null;
-  if (cached) return cached;
+  if (cached) {
+    if (typeof cached.getSheetByName === 'function') return cached;
+    try {
+      const ss = SpreadsheetApp.openById(cached);
+      if (typeof putCacheValue_ === 'function') putCacheValue_(cacheKey, ss, 300);
+      return ss;
+    } catch (e) {
+      if (typeof logError_ === 'function') logError_('getGlobalDb_', e);
+    }
+  }
   const props = PropertiesService.getScriptProperties();
   const propName = (typeof PROP_GLOBAL_MASTER_DB !== 'undefined') ? PROP_GLOBAL_MASTER_DB : 'Global_Master_DB';
   const id = props.getProperty(propName);
@@ -112,7 +78,16 @@ function getTeacherDb_(teacherCode) {
   if (!teacherCode) return null;
   const cacheKey = 'teacherdb_' + teacherCode;
   const cached = typeof getCacheValue_ === 'function' ? getCacheValue_(cacheKey) : null;
-  if (cached) return cached;
+  if (cached) {
+    if (typeof cached.getSheetByName === 'function') return cached;
+    try {
+      const ss = SpreadsheetApp.openById(cached);
+      if (typeof putCacheValue_ === 'function') putCacheValue_(cacheKey, ss, 300);
+      return ss;
+    } catch (e) {
+      if (typeof logError_ === 'function') logError_('getTeacherDb_', e);
+    }
+  }
   const props = PropertiesService.getScriptProperties();
   const id = props.getProperty('ssId_' + teacherCode);
   if (!id) return null;


### PR DESCRIPTION
## Summary
- remove duplicate helper functions
- ensure cached Spreadsheet IDs are reopened before use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a7612ad8832bad3f0dd2844a1ec2