### PR TITLE
Improve CSV upload duplicate handling

### DIFF
--- a/src/User.gs
+++ b/src/User.gs
@@ -7,31 +7,46 @@ function registerUsersFromCsv(teacherCode, csvData) {
   const userSheet = globalDb.getSheetByName('Global_Users');
   const enrollSheet = teacherDb.getSheetByName('Enrollments');
   if (!userSheet || !enrollSheet) return { status: 'error', message: 'missing_sheet' };
-  const rows = Utilities.parseCsv(csvData);
+  const rows = Utilities.parseCsv(csvData).slice(1); // skip header row
   const now = new Date();
-  const existingEmails = userSheet.getRange(2,1,Math.max(0,userSheet.getLastRow()-1),1).getValues().flat().map(e=>String(e).toLowerCase());
+  const existingData = userSheet
+    .getRange(2, 1, Math.max(0, userSheet.getLastRow() - 1), 3)
+    .getValues();
+  const existingMap = {};
+  existingData.forEach(r => {
+    const email = String(r[0] || '').trim().toLowerCase();
+    const role = String(r[2] || '').trim().toLowerCase();
+    if (email) existingMap[email] = role;
+  });
   const userAppend = [];
   const enrollAppend = [];
+  const duplicates = [];
+  const seen = {};
   let created = 0;
-  rows.forEach(r => {
+  rows.forEach((r, idx) => {
     const email = String(r[0] || '').trim();
     if (!email) return;
+    const emailLower = email.toLowerCase();
+    const isExistingStudent = existingMap[emailLower] === 'student';
+    if (isExistingStudent || seen[emailLower]) {
+      duplicates.push(email);
+      return;
+    }
     const name = r[1] || '';
     const grade = r[2] || '';
     const cls = r[3] || '';
     const number = r[4] || '';
-    if (!existingEmails.includes(email.toLowerCase())) {
-      userAppend.push([email, name, 'student', 0, 1, 0, '', now, now, 1]);
-      existingEmails.push(email.toLowerCase());
-      created++;
-    }
+    userAppend.push([email, name, 'student', 0, 1, 0, '', now, now, 1]);
     enrollAppend.push([email, 'student', grade, cls, number, now]);
+    existingMap[emailLower] = 'student';
+    seen[emailLower] = true;
+    created++;
   });
   if (userAppend.length)
     userSheet.getRange(userSheet.getLastRow()+1,1,userAppend.length,userAppend[0].length).setValues(userAppend);
   if (enrollAppend.length)
     enrollSheet.getRange(enrollSheet.getLastRow()+1,1,enrollAppend.length,enrollAppend[0].length).setValues(enrollAppend);
-  return { status: 'success', created: created, enrolled: enrollAppend.length };
+  return { status: 'success', created: created, enrolled: enrollAppend.length, duplicates: duplicates };
 }
 
 function registerSingleStudent(teacherCode, studentData) {

--- a/src/manage.html
+++ b/src/manage.html
@@ -1355,7 +1355,11 @@
       function onBulkRegisterSuccess(res) {
         hideLoadingOverlay();
         closeCsvUploadModal();
-        showToast(`新規${res.created}名、クラスへ${res.enrolled}名を登録しました`);
+        let msg = `新規${res.created}名、クラスへ${res.enrolled}名を登録しました`;
+        if (res.duplicates && res.duplicates.length) {
+          msg += `\n重複アドレス: ${res.duplicates.join(', ')}`;
+        }
+        showToast(msg);
         loadDashboardData(teacherCode);
       }
 

--- a/tests/User.test.js
+++ b/tests/User.test.js
@@ -44,9 +44,11 @@ test('registerUsersFromCsv creates new users and enrollments', () => {
   loadUser(context);
   context.getTeacherDb_ = () => teacherDb;
   context.getGlobalDb_ = () => globalDb;
-  const csv = 'alice@example.com,Alice,1,A,1\nbob@example.com,Bob,1,A,2';
+  const csv = 'Email,Name,Grade,Class,Number\n' +
+              'alice@example.com,Alice,1,A,1\n' +
+              'bob@example.com,Bob,1,A,2';
   const res = context.registerUsersFromCsv('TC', csv);
-  expect(res).toEqual({ status:'success', created:2, enrolled:2 });
+  expect(res).toEqual({ status:'success', created:2, enrolled:2, duplicates: [] });
   expect(userRows.length).toBe(3);
   expect(enrollRows.length).toBe(3);
   expect(userRows[1][0]).toBe('alice@example.com');
@@ -90,12 +92,14 @@ test('registerUsersFromCsv skips existing users', () => {
   loadUser(context);
   context.getTeacherDb_ = () => teacherDb;
   context.getGlobalDb_ = () => globalDb;
-  const csv = 'alice@example.com,Alice,1,A,1\ncharlie@example.com,Charlie,1,B,3';
+  const csv = 'Email,Name,Grade,Class,Number\n' +
+              'alice@example.com,Alice,1,A,1\n' +
+              'charlie@example.com,Charlie,1,B,3';
   const res = context.registerUsersFromCsv('TC', csv);
-  expect(res).toEqual({ status:'success', created:1, enrolled:2 });
+  expect(res).toEqual({ status:'success', created:1, enrolled:1, duplicates: ['alice@example.com'] });
   expect(userRows.length).toBe(3);
   expect(userRows[2][0]).toBe('charlie@example.com');
-  expect(enrollRows.length).toBe(3);
+  expect(enrollRows.length).toBe(2);
 });
 
 test('registerSingleStudent adds user and enrollment', () => {


### PR DESCRIPTION
## Summary
- skip CSV header row when registering users
- notify user about duplicate emails
- only add unique rows to roster
- show duplicates in manage.html toast
- update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847ae032380832bb38bc551bb8523d0