### PR TITLE
Adjust teacher login flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,8 +235,8 @@ This project is licensed under the [MIT License](LICENSE).
 * **Process:**
     1. `Session.getEffectiveUser().getEmail()`で`email`を取得。
     2. `PropertiesService`から`teacherCode_<email>`をキーに`teacherCode`を取得。
-    3. `teacherCode`が取得できた場合、`processLoginBonus(email)`を呼び出す。
-* **Output:**
+    3. `teacherCode`が取得できた場合、その`teacherCode`を返す。
+    * **Output:**
     * **Success:** `{ status: "ok", teacherCode: <string> }`
     * **Failure:** `{ status: "not_found" }`
 
@@ -261,7 +261,7 @@ This project is licensed under the [MIT License](LICENSE).
 ### 3.5. 共通ロジック
 #### `processLoginBonus(userEmail)`
 * **目的:** ログインボーナスの付与と連続ログイン日数の更新。
-* **トリガー:** `loginAsTeacher`, `loginAsStudent` の認証成功直後に内部的に呼び出される。
+* **トリガー:** `loginAsStudent` の認証成功直後に内部的に呼び出される。
 * **Input:**
     * `userEmail` (string): ログインしたユーザーのEmail。
 * **Process:**
@@ -306,7 +306,7 @@ This project is licensed under the [MIT License](LICENSE).
     * **Output:** `{ status: "ok", teacherCode: <string> }`
 * **`loginAsTeacher()`:**
     * **Input:** (none)
-    * **Process:** 1. `email`を取得. 2. `PropertiesService`から`teacherCode`を検索. 3. `processLoginBonus(email)`を呼び出し.
+    * **Process:** 1. `email`を取得. 2. `PropertiesService`から`teacherCode`を検索.
     * **Output:** `{ status: "ok", teacherCode: <string> }`
 * **`loginAsStudent(teacherCode)`:**
     * **Input:** `teacherCode` (string)

--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -87,7 +87,6 @@ function handleTeacherLogin() {
   const props = PropertiesService.getScriptProperties();
   const code = props.getProperty('teacherCode_' + email);
   if (code) {
-    try { if (typeof processLoginBonus === 'function') processLoginBonus(email); } catch (_) {}
     return { status: 'ok', teacherCode: code };
   }
   return { status: 'new_teacher_prompt_key' };
@@ -98,7 +97,6 @@ function loginAsTeacher() {
   const props = PropertiesService.getScriptProperties();
   const teacherCode = props.getProperty('teacherCode_' + email);
   if (teacherCode) {
-    try { if (typeof processLoginBonus === 'function') processLoginBonus(email); } catch (_) {}
     return { status: 'ok', teacherCode: teacherCode };
   }
   return { status: 'not_found' };

--- a/src/login.html
+++ b/src/login.html
@@ -311,7 +311,7 @@
           window.top.location.href = redirect;
         };
       } else {
-        document.getElementById('welcomeText').textContent = `${new Date().toLocaleDateString('ja-JP')} にログインしました。ログインボーナスが付与されました。`;
+        document.getElementById('welcomeText').textContent = `${new Date().toLocaleDateString('ja-JP')} にログインしました。`;
         const w = document.getElementById('welcomeBack');
         w.classList.remove('hidden');
         document.getElementById('closeWelcome').onclick = () => {

--- a/tests/Auth.test.js
+++ b/tests/Auth.test.js
@@ -11,7 +11,7 @@ function loadAuth(context) {
   vm.runInNewContext(code, context);
 }
 
-test('loginAsTeacher returns ok and calls bonus', () => {
+test('loginAsTeacher returns ok without bonus', () => {
   const props = { 'teacherCode_teacher@example.com': 'TC123' };
   const context = {
     PropertiesService: { getScriptProperties: () => ({ getProperty: k => props[k] }) },
@@ -21,7 +21,7 @@ test('loginAsTeacher returns ok and calls bonus', () => {
   loadAuth(context);
   const res = context.loginAsTeacher();
   expect(res).toEqual({ status: 'ok', teacherCode: 'TC123' });
-  expect(context.processLoginBonus).toHaveBeenCalledWith('teacher@example.com');
+  expect(context.processLoginBonus).not.toHaveBeenCalled();
 });
 
 test('loginAsTeacher returns not_found when missing', () => {
@@ -34,7 +34,7 @@ test('loginAsTeacher returns not_found when missing', () => {
   expect(res.status).toBe('not_found');
 });
 
-test('handleTeacherLogin differentiates new teacher', () => {
+test('handleTeacherLogin differentiates new teacher without bonus', () => {
   const props = { teacherPasscode: 'changeme' };
   const context = {
     PropertiesService: { getScriptProperties: () => ({ getProperty: k => props[k] }) },
@@ -47,7 +47,7 @@ test('handleTeacherLogin differentiates new teacher', () => {
   props['teacherCode_new@example.com'] = 'NC123';
   res = context.handleTeacherLogin();
   expect(res).toEqual({ status: 'ok', teacherCode: 'NC123' });
-  expect(context.processLoginBonus).toHaveBeenCalledWith('new@example.com');
+  expect(context.processLoginBonus).not.toHaveBeenCalled();
 });
 
 test('loginAsStudent finds enrollment and global data', () => {


### PR DESCRIPTION
## Summary
- remove login bonus processing from teacher logins
- clarify docs about teacher login bonus
- update frontend teacher login message
- update unit tests accordingly

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847cefafaf8832b8a194ebf7436e76b