### PR TITLE
Add back button to UI pages

### DIFF
--- a/src/admin.html
+++ b/src/admin.html
@@ -8,6 +8,9 @@
   <link href="styles.css" rel="stylesheet">
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans p-4">
+  <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 mb-4" onclick="history.back();">
+    <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+  </button>
   <header class="mb-4">
     <h1 class="text-2xl font-bold">管理ダッシュボード</h1>
   </header>

--- a/src/board.html
+++ b/src/board.html
@@ -87,6 +87,9 @@
   <div class="w-full mx-auto">
     <header class="glass-panel rounded-xl p-4 mb-4 flex flex-col lg:flex-row justify-between items-center gap-4 shadow-lg">
         <div class="flex items-center gap-4 w-full lg:w-1/4">
+            <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700" onclick="history.back();">
+                <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+            </button>
             <a href="#" id="backLink" class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 text-sm flex items-center gap-2 flex-shrink-0"></a>
             <p id="answerCount" class="text-sm text-gray-400 hidden sm:flex items-center gap-2"></p>
         </div>

--- a/src/class-select.html
+++ b/src/class-select.html
@@ -9,6 +9,9 @@
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans min-h-screen flex items-center justify-center p-4">
   <main class="w-full max-w-xl space-y-4">
+    <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 mb-4" onclick="history.back();">
+      <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+    </button>
     <h1 class="text-xl font-bold text-center mb-2">クラスを選択</h1>
     <div id="class-grid" class="grid grid-cols-1 sm:grid-cols-2 gap-4"></div>
   </main>

--- a/src/leaderboard.html
+++ b/src/leaderboard.html
@@ -8,6 +8,9 @@
   <link href="styles.css" rel="stylesheet">
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans min-h-screen p-4">
+  <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 mb-4" onclick="history.back();">
+    <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+  </button>
   <h1 class="text-xl font-bold mb-4">ランキング</h1>
   <table class="min-w-full text-sm" id="leaderboardTable">
     <thead><tr class="text-left"><th>Rank</th><th>Name</th><th>Lv</th><th>XP</th></tr></thead>

--- a/src/login.html
+++ b/src/login.html
@@ -31,6 +31,9 @@
         <h1 class="text-3xl font-bold tracking-widest">StudyQuest</h1>
         <p class="text-gray-400 text-sm mt-1">冒険の準備をしよう！</p>
       </div>
+      <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 mb-4" onclick="history.back();">
+        <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+      </button>
       <div id="stage1" class="grid grid-cols-2 gap-4 mb-4">
         <button id="choose-teacher" class="game-btn bg-purple-600 text-white p-3 rounded-lg font-bold border-purple-800 hover:bg-purple-500">教師</button>
         <button id="choose-student" class="game-btn bg-cyan-600 text-white p-3 rounded-lg font-bold border-cyan-800 hover:bg-cyan-500">生徒</button>

--- a/src/manage.html
+++ b/src/manage.html
@@ -103,6 +103,9 @@
 
         <!-- Header -->
         <header class="glass-panel rounded-xl p-3 flex flex-col sm:flex-row justify-between items-center gap-4 shadow-lg">
+            <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700" onclick="history.back();">
+                <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+            </button>
             <div class="flex items-center gap-3">
                 <i data-lucide="shield-check" class="w-8 h-8 text-pink-400"></i>
                 <h1 class="text-2xl font-bold tracking-wider text-white">管理パネル</h1>

--- a/src/profile.html
+++ b/src/profile.html
@@ -19,6 +19,9 @@
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans min-h-screen p-4 pixel-bg">
   <main class="max-w-3xl mx-auto space-y-4">
+    <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 mb-4" onclick="history.back();">
+      <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+    </button>
     <div id="statusCard" class="glass-panel p-4 rounded-xl space-y-3">
       <h1 class="text-xl font-bold">プロフィール</h1>
       <div>

--- a/src/quest.html
+++ b/src/quest.html
@@ -86,6 +86,9 @@
   <div class="max-w-7xl mx-auto h-[calc(100vh-2rem)] flex flex-col gap-4">
     <!-- ===== ヘッダー (アイコン削除) ===== -->
     <header class="glass-panel rounded-xl p-3 flex flex-col sm:flex-row justify-between items-center gap-4 shadow-lg">
+      <button class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700" onclick="history.back();">
+        <i data-lucide="arrow-left" class="w-4 h-4"></i>戻る
+      </button>
       <div class="flex items-center gap-3">
         <i data-lucide="swords" class="w-8 h-8 text-cyan-400"></i>
         <h1 class="text-2xl font-bold tracking-wider text-white">StudyQuest</h1>


### PR DESCRIPTION
## Summary
- add a universal "戻る" button to all front-end HTML pages
- keep the board page's dynamic back link
- ensure pages use the existing game-btn styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480e8572e0832b91ff59fc31a97197