### PR TITLE
Refactor global DB init

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@
 
 2.  **グローバルDBの初期化:**
     * Apps Script エディタで `createGlobalMasterDb` を実行し、`StudyQuest_Global_Master_DB` スプレッドシートを作成します。
-    * 生成されたスプレッドシートIDは `GLOBAL_DB_ID` と `Global_Master_DB` の両方のプロパティとして保存されます。
+    * 生成されたスプレッドシートIDは `Global_Master_DB` プロパティに保存されます。
+    * 旧バージョンから移行する場合、スクリプトプロパティ `GLOBAL_DB_ID` が残っていれば手動で削除してください。
     * 作成されたスプレッドシートを、StudyQuest を利用するすべての教師と共有するか、Web アプリの実行ユーザーを「自分」に設定してください。
 
 3.  **教師としての初回ログイン:**

--- a/src/Global.gs
+++ b/src/Global.gs
@@ -1,19 +1,17 @@
 function initGlobalDb() {
   const props = PropertiesService.getScriptProperties();
   const propName = (typeof PROP_GLOBAL_MASTER_DB !== 'undefined') ? PROP_GLOBAL_MASTER_DB : 'Global_Master_DB';
-  const existing = props.getProperty('GLOBAL_DB_ID');
+  const existing = props.getProperty(propName);
   if (existing) {
     try {
       SpreadsheetApp.openById(existing);
-      if (typeof props.setProperty === 'function') props.setProperty(propName, existing);
       return { status: 'exists', id: existing };
     } catch (e) {
-      props.deleteProperty('GLOBAL_DB_ID');
+      props.deleteProperty(propName);
     }
   }
   const ss = SpreadsheetApp.create('StudyQuest_Global_Master_DB');
   if (typeof props.setProperty === 'function') {
-    props.setProperty('GLOBAL_DB_ID', ss.getId());
     props.setProperty(propName, ss.getId());
   }
 

--- a/tests/GlobalInit.test.js
+++ b/tests/GlobalInit.test.js
@@ -30,7 +30,7 @@ test('initGlobalDb creates sheets and stores id', () => {
   loadGlobal(context);
   const result = context.initGlobalDb();
   expect(result.status).toBe('created');
-  expect(props.GLOBAL_DB_ID).toBe('gid');
+  expect(props.Global_Master_DB).toBe('gid');
   expect(userSheet.setName).toHaveBeenCalledWith('Global_Users');
   expect(context.SpreadsheetApp.create).toHaveBeenCalledWith('StudyQuest_Global_Master_DB');
   expect(ssStub.insertSheet).toHaveBeenCalledWith('Global_Trophies_Log');
@@ -38,7 +38,7 @@ test('initGlobalDb creates sheets and stores id', () => {
 });
 
 test('initGlobalDb returns existing when already created', () => {
-  const props = { GLOBAL_DB_ID: 'gid' };
+  const props = { Global_Master_DB: 'gid' };
   const context = {
     PropertiesService: { getScriptProperties: () => ({ getProperty: k => props[k], deleteProperty: k => delete props[k] }) },
     SpreadsheetApp: {


### PR DESCRIPTION
## Summary
- remove `GLOBAL_DB_ID` handling from Global.gs
- use only `Global_Master_DB` property in initGlobalDb
- update unit tests for new property
- document migration step in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848240feaa0832ba66a308f2c543a4a