### PR TITLE
Add handle name greeting and UI fixes

### DIFF
--- a/src/class-select.html
+++ b/src/class-select.html
@@ -46,7 +46,7 @@
           const code = encodeURIComponent(c.teacherCode);
             return `
               <div class="p-4 bg-gray-800 rounded-lg shadow space-y-2">
-                <p class="font-bold">${escapeHtml(c.teacherName || c.className)}</p>
+                <p class="font-bold">${escapeHtml(c.teacherName || '')}<span class="text-xs text-gray-400 ml-1">(${escapeHtml(c.teacherCode)})</span></p>
                 <div class="flex gap-2 text-sm">
                   <a href="${SCRIPT_URL}?page=quest&teacher=${code}" class="flex-1 px-2 py-1 text-center bg-blue-600 rounded hover:bg-blue-500">クエストに挑戦</a>
                   <a href="${SCRIPT_URL}?page=leaderboard&teacher=${code}" class="flex-1 px-2 py-1 text-center bg-purple-600 rounded hover:bg-purple-500">ランキング</a>

--- a/src/login.html
+++ b/src/login.html
@@ -73,7 +73,7 @@
       <p class="mb-2">🎉 初回ログインありがとうございます！</p>
       <p class="mb-2">Google Drive にデータベース「StudyQuest_<span id="newCodeSpan"></span>」を作成しました。</p>
       <p class="mb-2">教師コード: <span id="newCodeSpan2"></span></p>
-      <input id="teacherNameInput" class="w-full p-2 text-black border mb-4" placeholder="表示名を入力してください">
+      <input id="teacherNameInput" class="w-full p-2 bg-black text-white border mb-4" placeholder="表示名を入力してください">
       <button id="closeFirstMsg" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 w-full">続行</button>
     </div>
   </div>

--- a/src/manage.html
+++ b/src/manage.html
@@ -106,6 +106,7 @@
             <div class="flex items-center gap-3">
                 <i data-lucide="shield-check" class="w-8 h-8 text-pink-400"></i>
                 <h1 class="text-2xl font-bold tracking-wider text-white">管理パネル</h1>
+                <p id="greetMsg" class="text-pink-300 text-sm font-bold mt-1"></p>
             </div>
             <div class="flex items-center gap-3">
                 <a id="backToLogin" href="<?!= scriptUrl.replace('/dev','/exec') ?>?page=login" target="_top" class="game-btn bg-gray-600 text-gray-200 px-4 py-2 rounded-lg font-bold border-gray-800 hover:bg-gray-700 text-sm flex items-center gap-2">
@@ -511,6 +512,13 @@
       document.getElementById('teacherCodeModal').addEventListener('click', () => {
         document.getElementById('teacherCodeModal').classList.add('hidden');
       });
+
+      google.script.run.withSuccessHandler(res => {
+        const el = document.getElementById('greetMsg');
+        if (res && res.name && el) {
+          el.textContent = `ようこそ、${escapeHtml(res.name)}先生！`;
+        }
+      }).getTeacherName(teacherCode);
 
       // Gemini 設定読み込み
       loadGeminiSettings();


### PR DESCRIPTION
## Summary
- ensure the initial name input is visible on dark background
- greet teachers by HandleName atop the management panel
- show teacher code and handle name when selecting a class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684846c76174832b9ea1ee51effd5ac2