### PR TITLE
Add progress stats to admin dashboard

### DIFF
--- a/src/Dashboard.gs
+++ b/src/Dashboard.gs
@@ -4,3 +4,55 @@ function loadDashboardData(teacherCode) {
     students: listStudents(teacherCode)
   };
 }
+
+/**
+ * getTaskCompletionStatus(teacherCode):
+ * 最新課題の提出状況を返す
+ */
+function getTaskCompletionStatus(teacherCode) {
+  teacherCode = String(teacherCode || '').trim();
+  var result = [];
+  var tasks = listTasks(teacherCode) || [];
+  if (tasks.length === 0) return result;
+
+  var students = listStudents(teacherCode) || [];
+  var classMap = getClassIdMap(teacherCode) || {};
+  var classMembers = {};
+  for (var i = 0; i < students.length; i++) {
+    var st = students[i];
+    var key = st.grade + '-' + st.class;
+    if (!classMembers[key]) classMembers[key] = [];
+    classMembers[key].push(st.id);
+  }
+
+  var ss = getSpreadsheetByTeacherCode(teacherCode);
+  if (!ss) return result;
+  var sheet = ss.getSheetByName(CONSTS.SHEET_SUBMISSIONS);
+  var submitted = {};
+  if (sheet) {
+    var lastRow = sheet.getLastRow();
+    if (lastRow >= 2) {
+      var rows = sheet.getRange(2, 1, lastRow - 1, 2).getValues();
+      for (var r = 0; r < rows.length; r++) {
+        var sid = String(rows[r][0] || '').trim();
+        var tid = String(rows[r][1] || '').trim();
+        if (!sid || !tid) continue;
+        if (!submitted[tid]) submitted[tid] = {};
+        submitted[tid][sid] = true;
+      }
+    }
+  }
+
+  var limit = 5;
+  for (var t = 0; t < tasks.length && t < limit; t++) {
+    var task = tasks[t];
+    var className = classMap[task.classId] || '';
+    var total = classMembers[className] ? classMembers[className].length : 0;
+    var count = submitted[task.id] ? Object.keys(submitted[task.id]).length : 0;
+    var qText = '';
+    try { qText = JSON.parse(task.q).question || task.q; } catch (e) { qText = task.q; }
+    result.push({ id: task.id, question: qText, count: count, total: total });
+  }
+
+  return result;
+}

--- a/src/admin.html
+++ b/src/admin.html
@@ -35,6 +35,15 @@
     <h2 class="font-bold mb-2">課題情報</h2>
     <ul id="taskList" class="list-disc pl-4 text-sm"></ul>
   </section>
+  <section class="mb-6">
+    <h2 class="font-bold mb-2">課題進捗</h2>
+    <table class="min-w-full border text-sm" id="progressTable">
+      <thead>
+        <tr><th class="border px-2">課題</th><th class="border px-2">完了数</th><th class="border px-2">総数</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </section>
   <section>
     <h2 class="font-bold mb-2">最近の提出</h2>
     <ul id="logList" class="list-disc pl-4 text-sm"></ul>
@@ -62,6 +71,7 @@
       google.script.run.withSuccessHandler(renderClassTable).getClassStatistics(teacherCode);
       google.script.run.withSuccessHandler(renderStudentTable).listStudents(teacherCode);
       google.script.run.withSuccessHandler(renderTaskList).listTasks(teacherCode);
+      google.script.run.withSuccessHandler(renderProgressTable).getTaskCompletionStatus(teacherCode);
       google.script.run.withSuccessHandler(renderLogList).listBoard(teacherCode);
     }
 
@@ -92,6 +102,13 @@
         let q = '';
         try { q = JSON.parse(t.q).question || ''; } catch(e) { q = t.q; }
         return `<li>${q}</li>`;
+      }).join('');
+    }
+
+    function renderProgressTable(progress) {
+      const tbody = document.querySelector('#progressTable tbody');
+      tbody.innerHTML = (progress || []).map(p => {
+        return `<tr><td class="border px-2">${escapeHtml(String(p.question))}</td><td class="border px-2 text-right">${p.count}</td><td class="border px-2 text-right">${p.total}</td></tr>`;
       }).join('');
     }
 

--- a/tests/Dashboard.test.js
+++ b/tests/Dashboard.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadDashboard(context) {
+  const consts = fs.readFileSync(path.join(__dirname, '../src/consts.gs'), 'utf8');
+  vm.runInNewContext(consts, context);
+  const utils = fs.readFileSync(path.join(__dirname, '../src/Utils.gs'), 'utf8');
+  vm.runInNewContext(utils, context);
+  const code = fs.readFileSync(path.join(__dirname, '../src/Dashboard.gs'), 'utf8');
+  vm.runInNewContext(code, context);
+}
+
+test('getTaskCompletionStatus counts submissions per task', () => {
+  const subsData = [
+    ['s1','t1'],
+    ['s2','t1'],
+    ['s1','t2']
+  ];
+  const subsSheet = {
+    getLastRow: jest.fn(() => subsData.length + 1),
+    getRange: jest.fn(() => ({ getValues: () => subsData })),
+    getSheetByName: jest.fn()
+  };
+  const ssStub = { getSheetByName: name => name === 'Submissions' ? subsSheet : null };
+  const context = {
+    SHEET_SUBMISSIONS: 'Submissions',
+    getSpreadsheetByTeacherCode: () => ssStub,
+    listTasks: jest.fn(() => [
+      { id: 't1', classId: '1', q: '{"question":"Q1"}' },
+      { id: 't2', classId: '1', q: '{"question":"Q2"}' }
+    ]),
+    listStudents: jest.fn(() => [
+      { id: 's1', grade: 1, class: 'A' },
+      { id: 's2', grade: 1, class: 'A' },
+      { id: 's3', grade: 1, class: 'A' }
+    ]),
+    getClassIdMap: jest.fn(() => ({ '1': '1-A' }))
+  };
+  loadDashboard(context);
+  const res = context.getTaskCompletionStatus('X');
+  expect(res[0].count).toBe(2);
+  expect(res[0].total).toBe(3);
+  expect(res[1].count).toBe(1);
+  expect(res[1].total).toBe(3);
+});


### PR DESCRIPTION
## Summary
- display task progress on admin page
- support progress data via `getTaskCompletionStatus`
- add unit test for progress calculation

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68485604bcac832b8a458cc0c1cf4095