### PR TITLE
Add admin navigation links

### DIFF
--- a/src/admin.html
+++ b/src/admin.html
@@ -8,9 +8,12 @@
   <link href="styles.css" rel="stylesheet">
 </head>
 <body class="bg-[#1a1b26] text-gray-200 font-sans p-4">
-  <header class="mb-4">
-    <h1 class="text-2xl font-bold">管理ダッシュボード</h1>
-    <p id="teacherName" class="text-sm text-gray-400"></p>
+  <header class="mb-4 flex justify-between items-center">
+    <div>
+      <h1 class="text-2xl font-bold">管理ダッシュボード</h1>
+      <p id="teacherName" class="text-sm text-gray-400"></p>
+    </div>
+    <a href="<?!= scriptUrl.replace('/dev','/exec') ?>?page=manage&teacher=<?!= teacher ?>" target="_top" class="game-btn bg-gray-600 text-gray-200 px-3 py-1 rounded-lg font-bold border-gray-800 hover:bg-gray-700 text-sm">管理画面へ戻る</a>
   </header>
   <section id="stats" class="mb-4"></section>
   <section class="mb-6">

--- a/src/manage.html
+++ b/src/manage.html
@@ -198,8 +198,10 @@
                 <!-- Dashboard Panel -->
                 <section class="glass-panel rounded-xl p-4 shadow-lg">
                     <h2 class="text-xl font-bold mb-4 flex items-center gap-2 border-b-2 border-gray-600 pb-2">
-                        <i data-lucide="layout-dashboard" class="w-6 h-6 text-cyan-400"></i>
-                        <span>ダッシュボード</span>
+                        <a id="adminPageLink" href="<?!= scriptUrl.replace('/dev','/exec') ?>?page=admin&teacher=<?!= teacher ?>" target="_top" class="flex items-center gap-2 hover:text-cyan-300">
+                            <i data-lucide="layout-dashboard" class="w-6 h-6 text-cyan-400"></i>
+                            <span>ダッシュボード</span>
+                        </a>
                     </h2>
                     <div class="space-y-4">
                         <div class="flex justify-around text-center">


### PR DESCRIPTION
## Summary
- link Manage page dashboard header to the admin dashboard
- add a return link in the Admin page header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485acb985c832bb5a3c469c8946b24