### PR TITLE
Add ownerName support in settings

### DIFF
--- a/src/Migration.gs
+++ b/src/Migration.gs
@@ -28,3 +28,56 @@ function addDraftColumn(teacherCode) {
   sheet.getRange(1, Math.max(8, lastCol + 1)).setValue('draft');
   return true;
 }
+
+/**
+ * migrateOwnerNames():
+ * Settings シートに ownerName が無い教師DB へ追加します。
+ */
+function migrateOwnerNames() {
+  var props = PropertiesService.getScriptProperties();
+  var keys = props.getKeys() || [];
+  var codes = [];
+  for (var i = 0; i < keys.length; i++) {
+    var k = keys[i];
+    if (k.indexOf(CONSTS.PROP_TEACHER_SSID_PREFIX) === 0) {
+      codes.push(k.substring(CONSTS.PROP_TEACHER_SSID_PREFIX.length));
+    }
+  }
+  var gdb = getGlobalDb_();
+  if (!gdb) return { migrated: 0 };
+  var us = gdb.getSheetByName(CONSTS.SHEET_GLOBAL_USERS);
+  if (!us) return { migrated: 0 };
+  var uLast = us.getLastRow();
+  var map = {};
+  if (uLast >= 2) {
+    var rows = us.getRange(2, 1, uLast - 1, 2).getValues();
+    for (var j = 0; j < rows.length; j++) {
+      map[String(rows[j][0]).trim().toLowerCase()] = rows[j][1];
+    }
+  }
+  var count = 0;
+  for (var c = 0; c < codes.length; c++) {
+    var code = codes[c];
+    var ss = getSpreadsheetByTeacherCode(code);
+    if (!ss) continue;
+    var sheet = ensureSettingsSheet_(ss);
+    var last = sheet.getLastRow();
+    var ownerName = '';
+    var ownerEmail = '';
+    if (last >= 2) {
+      var vals = sheet.getRange(2, 1, last - 1, 2).getValues();
+      for (var r = 0; r < vals.length; r++) {
+        if (String(vals[r][0]) === 'ownerName') ownerName = vals[r][1];
+        else if (String(vals[r][0]) === 'ownerEmail') ownerEmail = vals[r][1];
+      }
+    }
+    if (!ownerName && ownerEmail) {
+      var n = map[String(ownerEmail).trim().toLowerCase()] || '';
+      if (n) {
+        sheet.appendRow(['ownerName', n]);
+        count++;
+      }
+    }
+  }
+  return { migrated: count };
+}

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -318,14 +318,31 @@ function ensureSettingsSheet_(ss) {
 }
 
 function saveTeacherSettings_(teacherCode, obj) {
-  const ss = getSpreadsheetByTeacherCode(teacherCode);
+  var ss = getSpreadsheetByTeacherCode(teacherCode);
   if (!ss) return;
-  const sheet = ensureSettingsSheet_(ss);
+  var sheet = ensureSettingsSheet_(ss);
+
+  var ownerEmail = '';
+  var ownerName  = '';
+  var last = sheet.getLastRow();
+  if (last >= 2) {
+    var rows = sheet.getRange(2, 1, last - 1, 2).getValues();
+    for (var i = 0; i < rows.length; i++) {
+      if (String(rows[i][0]) === 'ownerEmail') ownerEmail = rows[i][1];
+      if (String(rows[i][0]) === 'ownerName') ownerName = rows[i][1];
+    }
+  }
+
   sheet.clear();
   sheet.appendRow(['type', 'value1', 'value2']);
+  if (ownerEmail) sheet.appendRow(['ownerEmail', ownerEmail]);
+  if (ownerName)  sheet.appendRow(['ownerName', ownerName]);
   if (obj.persona !== undefined) sheet.appendRow(['persona', obj.persona, '']);
   if (Array.isArray(obj.classes)) {
-    obj.classes.forEach(c => sheet.appendRow(['class', c[0], c[1]]));
+    for (var j = 0; j < obj.classes.length; j++) {
+      var c = obj.classes[j];
+      sheet.appendRow(['class', c[0], c[1]]);
+    }
   }
   removeCacheValue_('settings_' + teacherCode);
 }

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -299,7 +299,17 @@ test('saveTeacherSettings persists values correctly and global key handling', ()
   const sheetStub = {
     clear: jest.fn(() => { sheetData.length = 1; }),
     appendRow: jest.fn(row => sheetData.push(row)),
-    getDataRange: jest.fn(() => ({ getValues: () => sheetData }))
+    getDataRange: jest.fn(() => ({ getValues: () => sheetData })),
+    getLastRow: jest.fn(() => sheetData.length),
+    getRange: jest.fn((r, c, nr, nc) => ({
+      getValues: () => {
+        const out = [];
+        for (let i = 0; i < nr; i++) {
+          out.push(sheetData[r - 1 + i].slice(c - 1, c - 1 + nc));
+        }
+        return out;
+      }
+    }))
   };
   const ssStub = {
     getSheetByName: jest.fn(() => sheetStub),


### PR DESCRIPTION
## Summary
- preserve ownerEmail/ownerName rows when saving settings
- update teacher name in Settings sheet
- read `ownerName` in `getTeacherName_`
- add migration helper for ownerName rows
- update unit tests for new logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684864d81700832ba9abb62816739d56