### PR TITLE
Fix quest creation and improve admin defaults

### DIFF
--- a/src/Task.gs
+++ b/src/Task.gs
@@ -42,7 +42,21 @@ function createTask(teacherCode, taskObj, selfEval) {
 
   const taskId = Utilities.getUuid();
   const classId = parsed && parsed.classId ? parsed.classId : '';
-  taskSheet.appendRow([taskId, classId, payloadAsJson, selfEval, new Date(), '', '', '']);
+  var choices = Array.isArray(parsed && parsed.choices) ?
+                JSON.stringify(parsed.choices) : '';
+  taskSheet.appendRow([
+    taskId,
+    classId,
+    parsed && parsed.subject || '',
+    parsed && parsed.question || '',
+    parsed && parsed.type || 'text',
+    choices,
+    selfEval,
+    new Date(),
+    parsed && parsed.persona || '',
+    '',
+    ''
+  ]);
   removeCacheValue_('tasks_' + teacherCode);
   removeCacheValue_('taskmap_' + teacherCode);
   removeCacheValue_('stats_' + teacherCode);

--- a/src/manage.html
+++ b/src/manage.html
@@ -305,40 +305,38 @@
                     <form id="taskForm" class="space-y-4">
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div>
-                                <label class="block text-sm mb-1 text-gray-400">タイトル</label>
-                                <input id="title" type="text" placeholder="クエストのタイトル" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
-                            </div>
-                            <div>
-                                <label class="block text-sm mb-1 text-gray-400">難易度</label>
-                                <select id="difficulty" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
-                                    <option value="easy">易しい</option>
-                                    <option value="medium">普通</option>
-                                    <option value="hard">難しい</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <div>
-                                <label class="block text-sm mb-1 text-gray-400">制限時間 (秒)</label>
-                                <input id="timeLimit" type="number" min="0" placeholder="例: 60" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
-                            </div>
-                            <div>
-                                <label class="block text-sm mb-1 text-gray-400">基本XP</label>
-                                <input id="xpBase" type="number" min="0" placeholder="例: 10" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <div>
                                 <label class="block text-sm mb-1 text-gray-400">教科</label>
                                 <input id="subject" type="text" list="subjectHistory" placeholder="例: 算数, 国語..." class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
                                 <datalist id="subjectHistory"></datalist>
                             </div>
                             <div>
-                                <label class="block text-sm mb-1 text-gray-400">対象クラス</label>
-                                <div id="taskClassButtons" class="flex flex-wrap gap-2"></div>
+                                <label class="block text-sm mb-1 text-gray-400">タイトル</label>
+                                <input id="title" type="text" placeholder="クエストのタイトル" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
                             </div>
                         </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm mb-1 text-gray-400">クエスト内容 (問題文)</label>
+                            <textarea id="question" rows="3" placeholder="ここに問題文を入力します。" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600"></textarea>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div>
+                                <label class="block text-sm mb-1 text-gray-400">難易度</label>
+                                <select id="difficulty" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
+                                    <option value="easy">易しい</option>
+                                    <option value="medium" selected>普通</option>
+                                    <option value="hard">難しい</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm mb-1 text-gray-400">制限時間</label>
+                                <select id="timeLimit" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
+                                    <option value="">なし</option>
+                                    <option value="180">3分</option>
+                                    <option value="300">5分</option>
+                                    <option value="420">7分</option>
+                                    <option value="600">10分</option>
+                                </select>
+                            </div>
                             <div>
                                 <label class="block text-sm mb-1 text-gray-400">ステータス</label>
                                 <select id="status" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600">
@@ -347,9 +345,15 @@
                                     <option value="closed">終了</option>
                                 </select>
                             </div>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div>
-                                <label class="block text-sm mb-1 text-gray-400">作成日</label>
-                                <input id="createdAt" type="text" disabled class="w-full p-2 bg-gray-800/50 rounded-md border border-gray-600">
+                                <label class="block text-sm mb-1 text-gray-400">基本XP</label>
+                                <select id="xpBase" class="w-full p-2 bg-gray-800/80 rounded-md border border-gray-600"></select>
+                            </div>
+                            <div>
+                                <label class="block text-sm mb-1 text-gray-400">対象クラス</label>
+                                <div id="taskClassButtons" class="flex flex-wrap gap-2"></div>
                             </div>
                         </div>
                         <div>
@@ -515,6 +519,7 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       debugContentElem = document.getElementById('debugContent');
+      populateXpOptions();
       const debugPanel = document.getElementById('debugPanel');
       const versionEl = document.getElementById('versionInfo');
       const params = new URLSearchParams(location.search);
@@ -562,8 +567,8 @@
       document.getElementById('subject').addEventListener('input', saveDraft);
       document.getElementById('question').addEventListener('input', saveDraft);
       document.getElementById('difficulty').addEventListener('change', saveDraft);
-      document.getElementById('timeLimit').addEventListener('input', saveDraft);
-      document.getElementById('xpBase').addEventListener('input', saveDraft);
+      document.getElementById('timeLimit').addEventListener('change', saveDraft);
+      document.getElementById('xpBase').addEventListener('change', saveDraft);
       document.getElementById('status').addEventListener('change', saveDraft);
       document.getElementById('correctAnswer').addEventListener('input', saveDraft);
       document.getElementById('single-register-btn').addEventListener('click', openSingleRegisterModal);
@@ -679,10 +684,9 @@
           question: q,
           difficulty: document.getElementById('difficulty').value,
           timeLimit: document.getElementById('timeLimit').value,
-          xpBase: document.getElementById('xpBase').value,
+          xpBase: xpFinal,
           status: document.getElementById('status').value,
-          correctAnswer: document.getElementById('correctAnswer').value,
-          createdAt: document.getElementById('createdAt').value
+          correctAnswer: document.getElementById('correctAnswer').value
         };
         google.script.run.withSuccessHandler(id => { draftTaskId = id; }).saveDraftTask(teacherCode, draftPayload);
 
@@ -725,10 +729,9 @@
           question,
           difficulty: document.getElementById('difficulty').value,
           timeLimit: document.getElementById('timeLimit').value,
-          xpBase: document.getElementById('xpBase').value,
+          xpBase: xpFinal,
           status: document.getElementById('status').value,
-          correctAnswer: document.getElementById('correctAnswer').value,
-          createdAt: document.getElementById('createdAt').value
+          correctAnswer: document.getElementById('correctAnswer').value
         };
         google.script.run.withSuccessHandler(id => { draftTaskId = id; }).saveDraftTask(teacherCode, draftPayload);
         container.innerHTML = `Geminiが質問を生成中... <i data-lucide="loader-circle" class="inline-block animate-spin"></i>`;
@@ -795,7 +798,9 @@
         const q = document.getElementById('question').value.trim();
         const difficulty = document.getElementById('difficulty').value;
         const timeLimit = document.getElementById('timeLimit').value.trim();
-        const xpBase = document.getElementById('xpBase').value.trim();
+        let xpBase = parseInt(document.getElementById('xpBase').value.trim(), 10) || 100;
+        const diffBonusMap = { easy: 20, medium: 30, hard: 50 };
+        const xpFinal = xpBase + (diffBonusMap[difficulty] || 0);
         const status = document.getElementById('status').value;
         const correctAnswer = document.getElementById('correctAnswer').value.trim();
         const self = document.getElementById('selfEval').checked;
@@ -825,7 +830,7 @@
 
         // ペイロードをタイプ別に組み立て
         const makePayload = cls => {
-          const base = { classId: cls, title, subject, question: q, type: ansType, difficulty, timeLimit, xpBase, status, correctAnswer };
+          const base = { classId: cls, title, subject, question: q, type: ansType, difficulty, timeLimit, xpBase: xpFinal, status, correctAnswer };
           if (ansType === 'text') {
             return base;
           }
@@ -1043,12 +1048,11 @@
           if (d.title) document.getElementById('title').value = d.title;
           if (d.subject) document.getElementById('subject').value = d.subject;
           if (d.question) document.getElementById('question').value = d.question;
-          if (d.difficulty) document.getElementById('difficulty').value = d.difficulty;
-          if (d.timeLimit) document.getElementById('timeLimit').value = d.timeLimit;
-          if (d.xpBase) document.getElementById('xpBase').value = d.xpBase;
+          document.getElementById('difficulty').value = d.difficulty || 'medium';
+          document.getElementById('timeLimit').value = d.timeLimit || '';
+          document.getElementById('xpBase').value = d.xpBase || '100';
           if (d.status) document.getElementById('status').value = d.status;
           if (d.correctAnswer) document.getElementById('correctAnswer').value = d.correctAnswer;
-          document.getElementById('createdAt').value = d.createdAt || new Date().toISOString().slice(0,16).replace('T',' ');
         } catch (_) {}
       }
 
@@ -1061,8 +1065,7 @@
           timeLimit: document.getElementById('timeLimit').value,
           xpBase: document.getElementById('xpBase').value,
           status: document.getElementById('status').value,
-          correctAnswer: document.getElementById('correctAnswer').value,
-          createdAt: document.getElementById('createdAt').value
+          correctAnswer: document.getElementById('correctAnswer').value
         };
         try {
           localStorage.setItem('taskDraft', JSON.stringify(draft));
@@ -1076,6 +1079,19 @@
           localStorage.removeItem('taskDraft');
         } catch (_) {
           // ignore storage errors
+        }
+      }
+
+      function populateXpOptions() {
+        const sel = document.getElementById('xpBase');
+        if (!sel) return;
+        sel.innerHTML = '';
+        for (let v = 50; v <= 500; v += 50) {
+          const opt = document.createElement('option');
+          opt.value = String(v);
+          opt.textContent = v;
+          if (v === 100) opt.selected = true;
+          sel.appendChild(opt);
         }
       }
 
@@ -1111,14 +1127,13 @@
       // 9) フォームリセットヘルパー
       function resetForm() {
         document.getElementById('title').value = '';
-        document.getElementById('difficulty').value = 'easy';
+        document.getElementById('difficulty').value = 'medium';
         document.getElementById('timeLimit').value = '';
-        document.getElementById('xpBase').value = '';
+        document.getElementById('xpBase').value = '100';
         document.getElementById('subject').value = '';
         document.getElementById('question').value = '';
         document.getElementById('status').value = 'open';
         document.getElementById('correctAnswer').value = '';
-        document.getElementById('createdAt').value = new Date().toISOString().slice(0,16).replace('T',' ');
         const textRadio = document.querySelector('input[name="ansType"][value="text"]');
         if (textRadio) textRadio.checked = true;
         document.getElementById('aiToolsSection').classList.remove('hidden');
@@ -1171,14 +1186,13 @@
         try { data = JSON.parse(task.q); } catch (_) { return; }
         resetForm();
         document.getElementById('title').value = data.title || '';
-        document.getElementById('difficulty').value = data.difficulty || 'easy';
+        document.getElementById('difficulty').value = data.difficulty || 'medium';
         document.getElementById('timeLimit').value = data.timeLimit || '';
-        document.getElementById('xpBase').value = data.xpBase || '';
+        document.getElementById('xpBase').value = data.xpBase || '100';
         document.getElementById('subject').value = data.subject || '';
         document.getElementById('question').value = data.question || '';
         document.getElementById('status').value = task.closed ? 'closed' : 'open';
         document.getElementById('correctAnswer').value = data.correctAnswer || '';
-        document.getElementById('createdAt').value = task.date || new Date().toISOString().slice(0,16).replace('T',' ');
         const radio = document.querySelector(`input[name="ansType"][value="${data.type}"]`);
         if (radio) radio.checked = true;
         document.getElementById('aiToolsSection').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- fix reference error by creating proper task row
- revamp quest creation form
  - subject & title fields repositioned
  - difficulty, timer and status options inline with defaults
  - XP base dropdown with 50 point steps and default 100
  - remove unnecessary created-at handling
  - compute XP bonus from difficulty when saving tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486b702820832b8a2bd85d8552781f