### PR TITLE
Improve quest page error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ npm install   # install dev dependencies
 npm test      # execute Jest test suite
 ```
 
+## トラブルシューティング
+
+### クエスト画面が「ロード中…」のまま進まない
+
+デプロイした Web アプリの URL（末尾が `/exec` のもの）からアクセスしているか確認してください。HTML ファイルを直接開いた場合、`google.script.run` が利用できないためデータを読み込めません。スプレッドシートの編集権限がある場合でも、必ず Web アプリとして実行されている URL を使用してください。
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/quest.html
+++ b/src/quest.html
@@ -256,23 +256,38 @@
 
   function loadStudentData(code) {
     showLoadingOverlay();
-    if (google && google.script && google.script.run && typeof google.script.run.loadStudentData === 'function') {
-      google.script.run
-        .withSuccessHandler(data => {
-          state.userInfo = data.userInfo || null;
-          state.tasks = data.tasks || { uncompleted: [], completed: [] };
-          state.chatHistory = data.chatHistory || [];
-          updateProfileHeader();
-          renderLists(state.tasks.uncompleted || [], state.chatHistory);
-          hideLoadingOverlay();
-        })
-        .withFailureHandler(e => {
-          alert('データ取得に失敗しました: ' + e.message);
-          hideLoadingOverlay();
-        })
-        .loadStudentData(code);
+    if (google && google.script && google.script.run) {
+      if (typeof google.script.run.loadStudentData === 'function') {
+        google.script.run
+          .withSuccessHandler(data => {
+            state.userInfo = data.userInfo || null;
+            state.tasks = data.tasks || { uncompleted: [], completed: [] };
+            state.chatHistory = data.chatHistory || [];
+            updateProfileHeader();
+            renderLists(state.tasks.uncompleted || [], state.chatHistory);
+            hideLoadingOverlay();
+          })
+          .withFailureHandler(e => {
+            alert('データ取得に失敗しました: ' + e.message);
+            hideLoadingOverlay();
+          })
+          .loadStudentData(code);
+      } else if (typeof google.script.run.initStudent === 'function') {
+        google.script.run
+          .withSuccessHandler(() => {
+            loadTasks();
+            loadXp();
+          })
+          .withFailureHandler(e => {
+            alert('初期化に失敗しました: ' + e.message);
+            hideLoadingOverlay();
+          })
+          .initStudent(teacherCode, grade, classroom, number);
+      } else {
+        document.getElementById('loadingOverlay').textContent = 'Webアプリからアクセスしてください';
+      }
     } else {
-      initStudent();
+      document.getElementById('loadingOverlay').textContent = 'Webアプリからアクセスしてください';
     }
   }
 


### PR DESCRIPTION
## Summary
- show a clearer error if `google.script.run` isn't available when loading quests
- document how to resolve being stuck on "ロード中..." in the README

## Testing
- `./scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684899150d34832b87c8b1938336150c