### PR TITLE
Fix inconsistent sheet headers

### DIFF
--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -58,12 +58,12 @@ function setupInitialTeacher(secretKey) {
   const sheetDefs = [
     { name: 'Enrollments', headers: ['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt'] },
     { name: CONSTS.SHEET_STUDENTS, headers: ['StudentID','Grade','Class','Number','FirstLogin','LastLogin','LoginCount','TotalXP','Level','LastTrophyID'] },
-    { name: 'Tasks', headers: ['TaskID','Title','Subject','Question','Type','Choices','Difficulty','TimeLimit','XpBase','Status','CreatedAt','CorrectAnswer','Explanation','IsAiGenerated'] },
-    { name: 'Submissions', headers: ['SubmissionID','UserEmail','TaskID','Answer','EarnedXP','Bonuses','SubmittedAt','AiSummary'] },
+    { name: 'Tasks', headers: ['TaskID','ClassID','Subject','Question','Type','Choices','AllowSelfEval','CreatedAt','Persona','Status','draft','Difficulty','TimeLimit','XPBase','CorrectAnswer'] },
+    { name: 'Submissions', headers: ['StudentID','TaskID','Question','StartedAt','SubmittedAt','ProductURL','QuestionSummary','AnswerSummary','EarnedXP','TotalXP','Level','Trophy','Status'] },
     { name: 'Trophies', headers: ['TrophyID','Name','Description','IconURL','Condition'] },
     { name: 'Items', headers: ['ItemID','Name','Type','Price','Effect'] },
     { name: 'Leaderboard', headers: ['Rank','UserEmail','HandleName','Level','TotalXP','UpdatedAt'] },
-    { name: 'Settings', headers: ['Key','Value'] },
+    { name: 'Settings', headers: ['type','value1','value2'] },
     { name: 'TOC', headers: ['Sheet','Description'] }
   ];
   sheetDefs.forEach(def => {

--- a/tests/Auth.test.js
+++ b/tests/Auth.test.js
@@ -174,7 +174,7 @@ test('setupInitialTeacher creates resources and stores ids', () => {
   expect(userSheet.getRange).toHaveBeenCalledWith(2, 1, 1, 10);
   expect(userRange.setValues).toHaveBeenCalled();
   const settingsSheet = sheetMap['Settings'];
-  expect(settingsSheet.appendRow).toHaveBeenCalledWith(['Key','Value']);
+  expect(settingsSheet.appendRow).toHaveBeenCalledWith(['type','value1','value2']);
   expect(settingsSheet.appendRow).toHaveBeenCalledWith(['ownerEmail', 'teacher@example.com']);
   const sheetNames = Object.keys(sheetMap);
   ['Enrollments','Tasks','Submissions','Trophies','Items','Leaderboard','Settings','TOC'].forEach(name => {


### PR DESCRIPTION
## Summary
- align `setupInitialTeacher` sheet headers with `initTeacher`
- update tests for new headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489bea5f34832b9c83369723c40a9e