### PR TITLE
Enable admin debug mode

### DIFF
--- a/src/Auth.gs
+++ b/src/Auth.gs
@@ -281,3 +281,20 @@ function updateTeacherName(name) {
   }
   return { status: 'ok' };
 }
+
+function getCurrentUserRole() {
+  var email = Session.getEffectiveUser().getEmail();
+  var db = getGlobalDb_();
+  if (!db) return '';
+  var sheet = db.getSheetByName(CONSTS.SHEET_GLOBAL_USERS);
+  if (!sheet) return '';
+  var last = sheet.getLastRow();
+  if (last < 2) return '';
+  var rows = sheet.getRange(2, 1, last - 1, 3).getValues();
+  for (var i = 0; i < rows.length; i++) {
+    if (String(rows[i][0]).trim().toLowerCase() === email.toLowerCase()) {
+      return String(rows[i][2]).trim().toLowerCase();
+    }
+  }
+  return '';
+}

--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -100,3 +100,21 @@ function getTeacherDb_(teacherCode) {
     return null;
   }
 }
+
+function isAdminUser_(email) {
+  email = String(email || '').trim().toLowerCase();
+  if (!email) return false;
+  var db = getGlobalDb_();
+  if (!db) return false;
+  var sheet = db.getSheetByName(CONSTS.SHEET_GLOBAL_USERS);
+  if (!sheet) return false;
+  var last = sheet.getLastRow();
+  if (last < 2) return false;
+  var data = sheet.getRange(2, 1, last - 1, 3).getValues();
+  for (var i = 0; i < data.length; i++) {
+    if (String(data[i][0]).trim().toLowerCase() === email) {
+      return String(data[i][2]).trim().toLowerCase() === 'admin';
+    }
+  }
+  return false;
+}

--- a/src/board.html
+++ b/src/board.html
@@ -200,6 +200,16 @@
         const versionEl = document.getElementById('versionInfo');
         versionEl.textContent = version;
         versionEl.addEventListener('click', () => debugPanel.classList.toggle('hidden'));
+        if (google && google.script && google.script.run) {
+            google.script.run
+                .withSuccessHandler(role => {
+                    if (role === 'admin') {
+                        debugPanel.classList.remove('hidden');
+                        debug('admin mode');
+                    }
+                })
+                .getCurrentUserRole();
+        }
 
         const params = new URLSearchParams(location.search);
         let teacherCode = params.get('teacher') || teacherParam;

--- a/src/manage.html
+++ b/src/manage.html
@@ -538,6 +538,16 @@
       const debugCloseBtn = document.getElementById('debugClose');
       versionEl.addEventListener('click', () => debugPanel.classList.toggle('hidden'));
       debugCloseBtn.addEventListener('click', () => debugPanel.classList.add('hidden'));
+      if (google && google.script && google.script.run) {
+        google.script.run
+          .withSuccessHandler(role => {
+            if (role === 'admin') {
+              debugPanel.classList.remove('hidden');
+              debug('admin mode');
+            }
+          })
+          .getCurrentUserRole();
+      }
 
       debug('🔄 ページ読み込み完了');
       debug(`▶ teacherCode="${teacherCode}"`);


### PR DESCRIPTION
## Summary
- add helper `isAdminUser_`
- expose `getCurrentUserRole` for front-end role checks
- auto show debug panel when role is `admin`

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a4347b34832b86b60ed36f9e088a