### PR TITLE
Remove outdated GlobalDbSetup wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     * 本リポジトリをクローンし、`clasp` を使ってご自身のGoogleアカウントにApps Scriptプロジェクトをデプロイします。
 
 2.  **グローバルDBの初期化:**
-    * Apps Script エディタで `createGlobalMasterDb` を実行し、`StudyQuest_Global_Master_DB` スプレッドシートを作成します。
+    * Apps Script エディタで `initGlobalDb` を実行し、`StudyQuest_Global_Master_DB` スプレッドシートを作成します。
     * 生成されたスプレッドシートIDは `Global_Master_DB` プロパティに保存されます。
     * 旧バージョンから移行する場合、スクリプトプロパティ `GLOBAL_DB_ID` が残っていれば手動で削除してください。
     * 作成されたスプレッドシートを、StudyQuest を利用するすべての教師と共有するか、Web アプリの実行ユーザーを「自分」に設定してください。

--- a/src/GlobalDbSetup.gs
+++ b/src/GlobalDbSetup.gs
@@ -1,5 +1,0 @@
-function createGlobalMasterDb() {
-  const result = initGlobalDb();
-  return result;
-}
-


### PR DESCRIPTION
## Summary
- drop `src/GlobalDbSetup.gs`
- update README to reference `initGlobalDb`

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b1200124832bb9b42183eb855a9b