### PR TITLE
Fix mismatched sheet headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "studyquest",
-  "version": "1.0.251",
+  "version": "1.0.252",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studyquest",
-      "version": "1.0.251",
+      "version": "1.0.252",
       "devDependencies": {
         "@google/clasp": "^2.4.2",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "studyquest",
-  "version": "1.0.251",
+  "version": "1.0.252",
   "private": true,
   "scripts": {
     "deploy": "clasp push --force --no-open",

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -1,6 +1,6 @@
 
 // 共通定数は consts.gs に移動
-var SQ_VERSION = 'v1.0.247';
+var SQ_VERSION = 'v1.0.252';
 
 /**
  * doGet(e): テンプレートにパラメータを埋め込んで返す

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -175,17 +175,17 @@ function initTeacher(passcode) {
     {
       name: CONSTS.SHEET_STUDENTS,
       color: "4285f4",
-      header: ['StudentID', 'Grade', 'Class', 'Number', 'FirstLogin', 'LastLogin', 'LoginCount', 'TotalXP', 'Level', 'LastTrophyID'],
+      header: ['StudentID', 'Grade', 'Class', 'Number', 'FirstLogin', 'LastLogin', 'LoginCount', 'TotalXP', 'Level', 'LastTrophyID', 'TotalLikes'],
       description: "ログインした生徒の情報が記録されます。",
-      columnsJa: ['生徒ID','学年','組','番号','初回ログイン','最終ログイン','ログイン回数','累積XP','レベル','最終トロフィーID']
+      columnsJa: ['生徒ID','学年','組','番号','初回ログイン','最終ログイン','ログイン回数','累積XP','レベル','最終トロフィーID','累計いいね']
     },
     {
       name: CONSTS.SHEET_SUBMISSIONS,
       color: "008080",
       header: ['StudentID', 'TaskID', 'Question', 'StartedAt', 'SubmittedAt', 'ProductURL',
-               'QuestionSummary', 'AnswerSummary', 'EarnedXP', 'TotalXP', 'Level', 'Trophy', 'Status'],
+               'QuestionSummary', 'AnswerSummary', 'EarnedXP', 'TotalXP', 'Level', 'Trophy', 'Status', 'LikeScore'],
       description: "全生徒の回答の概要（ボード表示用）です。",
-      columnsJa: ['生徒ID','課題ID','問題文','開始日時','提出日時','成果物URL','問題概要','回答概要','付与XP','累積XP','レベル','トロフィー','ステータス']
+      columnsJa: ['生徒ID','課題ID','問題文','開始日時','提出日時','成果物URL','問題概要','回答概要','付与XP','累積XP','レベル','トロフィー','ステータス','いいねスコア']
     },
     {
       name: CONSTS.SHEET_AI_FEEDBACK,

--- a/src/User.gs
+++ b/src/User.gs
@@ -128,7 +128,7 @@ function deleteStudentsFromClass(teacherCode, emailsToDelete) {
   var data = sheet.getRange(2,1,lastRow-1,sheet.getLastColumn()).getValues();
   var filtered = data.filter(function(r) { return emailsToDelete.indexOf(String(r[0]).trim()) < 0; });
   sheet.clear();
-  sheet.appendRow(['UserEmail','Role','Grade','Class','Number','EnrolledAt']);
+  sheet.appendRow(['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt']);
   if (filtered.length) sheet.getRange(2,1,filtered.length,filtered[0].length).setValues(filtered);
   return { status: 'ok', deletedCount: data.length - filtered.length };
 }

--- a/tests/Code.test.js
+++ b/tests/Code.test.js
@@ -2,7 +2,7 @@ const { getSqVersion } = require('../src/Code.gs');
 const { getStudentTemplateCsv } = require('../src/StudentCsv.gs');
 
 test('getSqVersion returns correct version', () => {
-  expect(getSqVersion()).toBe('v1.0.247');
+  expect(getSqVersion()).toBe('v1.0.252');
 });
 
 test('getStudentTemplateCsv returns header row', () => {

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -289,7 +289,7 @@ test('initTeacher submissions sheet header matches README order', () => {
   context.generateTeacherCode = jest.fn(() => 'ABC123');
   context.initTeacher();
   const header = inserted['Submissions'].appendRow.mock.calls[0][0];
-  const expected = ['StudentID','TaskID','Question','StartedAt','SubmittedAt','ProductURL','QuestionSummary','AnswerSummary','EarnedXP','TotalXP','Level','Trophy','Status'];
+  const expected = ['StudentID','TaskID','Question','StartedAt','SubmittedAt','ProductURL','QuestionSummary','AnswerSummary','EarnedXP','TotalXP','Level','Trophy','Status','LikeScore'];
   expect(header).toEqual(expected);
 });
 

--- a/tests/User.test.js
+++ b/tests/User.test.js
@@ -16,7 +16,7 @@ test('registerUsersFromCsv creates new users and enrollments', () => {
     ['Email','HandleName','Role','Global_TotalXP','Global_Level','Global_Coins','EquippedTitle','CreatedAt','LastGlobalLogin','LoginStreak']
   ];
   const enrollRows = [
-    ['UserEmail','Role','Grade','Class','Number','EnrolledAt']
+    ['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt']
   ];
   const userSheet = {
     getLastRow: jest.fn(() => userRows.length),
@@ -64,7 +64,7 @@ test('registerUsersFromCsv skips existing users', () => {
     ['alice@example.com','Alice','student',0,1,0,'',now,now,1]
   ];
   const enrollRows = [
-    ['UserEmail','Role','Grade','Class','Number','EnrolledAt']
+    ['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt']
   ];
   const userSheet = {
     getLastRow: jest.fn(() => userRows.length),
@@ -106,7 +106,7 @@ test('registerUsersFromCsv skips existing users', () => {
 
 test('registerSingleStudent adds user and enrollment', () => {
   const userRows = [['Email','HandleName','Role','Global_TotalXP','Global_Level','Global_Coins','EquippedTitle','CreatedAt','LastGlobalLogin','LoginStreak']];
-  const enrollRows = [['UserEmail','Role','Grade','Class','Number','EnrolledAt']];
+  const enrollRows = [['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt']];
   const userSheet = {
     getLastRow: jest.fn(() => userRows.length),
     getRange: jest.fn(() => ({
@@ -133,7 +133,7 @@ test('registerSingleStudent adds user and enrollment', () => {
 
 test('deleteStudentsFromClass removes rows', () => {
   const enrollRows = [
-    ['UserEmail','Role','Grade','Class','Number','EnrolledAt'],
+    ['UserEmail','ClassRole','Grade','Class','Number','EnrolledAt'],
     ['a@example.com','student',1,1,1,new Date()],
     ['b@example.com','student',1,1,2,new Date()]
   ];


### PR DESCRIPTION
## Summary
- keep student DB in sync with backend
- match enrollment header with `ClassRole`
- adjust tests for new headers
- bump version to 1.0.252

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849057bdd18832baa650a68aeb0a6a4