### PR TITLE
Fix HTML include for escapeHtml

### DIFF
--- a/src/board.html
+++ b/src/board.html
@@ -145,7 +145,7 @@
 
 
   <script>
-    <?!= include('shared/escapeHtml.js'); ?>
+    <?!= include('shared/escapeHtml.html'); ?>
     const SCRIPT_URL = '<?!= typeof scriptUrl !== "undefined" ? scriptUrl.replace("/dev","/exec") : "" ?>';
     const teacherParam = '<?!= typeof teacher !== "undefined" ? teacher : "" ?>';
     const gradeParam = '<?!= typeof grade !== "undefined" ? grade : "" ?>';

--- a/src/class-select.html
+++ b/src/class-select.html
@@ -35,7 +35,7 @@
     </main>
   </div>
   <script>
-  <?!= include('shared/escapeHtml.js'); ?>
+  <?!= include('shared/escapeHtml.html'); ?>
   const SCRIPT_URL = '<?!= scriptUrl.replace("/dev", "/exec") ?>';
   const enrolledClasses = JSON.parse(sessionStorage.getItem('enrolledClasses') || '[]');
 

--- a/src/global-leaderboard.html
+++ b/src/global-leaderboard.html
@@ -24,7 +24,7 @@
     <tbody></tbody>
   </table>
   <script>
-    <?!= include('shared/escapeHtml.js'); ?>
+    <?!= include('shared/escapeHtml.html'); ?>
     function renderLeaderboard(data){
       const tbody=document.querySelector('#globalTable tbody');
       tbody.innerHTML=data.map(r=>`<tr><td>${r.rank}</td><td>${escapeHtml(r.handleName)}</td><td>${escapeHtml(r.level)}</td><td>${escapeHtml(r.totalXp)}</td></tr>`).join('');

--- a/src/leaderboard.html
+++ b/src/leaderboard.html
@@ -24,7 +24,7 @@
     <tbody></tbody>
   </table>
   <script>
-    <?!= include('shared/escapeHtml.js'); ?>
+    <?!= include('shared/escapeHtml.html'); ?>
     const params=new URLSearchParams(location.search);
     const teacher=params.get('teacher')||'';
     function renderLeaderboard(data){

--- a/src/manage.html
+++ b/src/manage.html
@@ -447,7 +447,7 @@
   </script>
 
   <script>
-  <?!= include('shared/escapeHtml.js'); ?>
+  <?!= include('shared/escapeHtml.html'); ?>
     // Lucide Icons を SVG に置き換える
     function renderIcons(scope) {
       // lucide.js の初期化を待つため、わずかに遅延させる

--- a/src/profile.html
+++ b/src/profile.html
@@ -45,7 +45,7 @@
   </main>
   <div id="trophyModal" class="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4 hidden"></div>
   <script>
-    <?!= include('shared/escapeHtml.js'); ?>
+    <?!= include('shared/escapeHtml.html'); ?>
     const allTrophies=[
       {id:'t1',name:'Beginner',icon:'award'},
       {id:'t2',name:'Explorer',icon:'compass'},

--- a/src/shared/escapeHtml.html
+++ b/src/shared/escapeHtml.html
@@ -1,0 +1,9 @@
+/**
+ * escapeHtml(text): Escape special HTML characters
+ * @param {string} text
+ * @return {string}
+ */
+function escapeHtml(text) {
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
+}


### PR DESCRIPTION
## Summary
- add `escapeHtml.html` so Apps Script can include the helper code
- update all pages to reference `shared/escapeHtml.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68490924b49c832b8536a7fa594c1319