### PR TITLE
Auto fetch teacher name

### DIFF
--- a/src/login.html
+++ b/src/login.html
@@ -75,7 +75,6 @@
       <p class="mb-2">🎉 初回ログインありがとうございます！</p>
       <p class="mb-2">Google Drive にデータベース「StudyQuest_<span id="newCodeSpan"></span>」を作成しました。</p>
       <p class="mb-2">教師コード: <span id="newCodeSpan2"></span></p>
-      <input id="teacherNameInput" class="w-full p-2 bg-black text-white border mb-4" placeholder="表示名を入力してください">
       <button id="closeFirstMsg" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 w-full">続行</button>
     </div>
   </div>
@@ -355,13 +354,9 @@
         const modal = document.getElementById('firstMessage');
         modal.classList.remove('hidden');
         document.getElementById('closeFirstMsg').onclick = function() {
-          const name = document.getElementById('teacherNameInput').value.trim();
-          if (!name) { alert('名前を入力してください'); return; }
-          google.script.run.withSuccessHandler(function() {
-            modal.classList.add('hidden');
-            localStorage.setItem(LS_TEACHER, '1');
-            window.top.location.href = redirect;
-          }).updateTeacherName(name);
+          modal.classList.add('hidden');
+          localStorage.setItem(LS_TEACHER, '1');
+          window.top.location.href = redirect;
         };
       } else {
         document.getElementById('welcomeText').textContent = `${new Date().toLocaleDateString('ja-JP')} にログインしました。`;

--- a/tests/Auth.test.js
+++ b/tests/Auth.test.js
@@ -153,6 +153,7 @@ test('setupInitialTeacher creates resources and stores ids', () => {
       setProperty: (k,v)=>{ props[k]=v; }
     }) },
     Session: { getEffectiveUser: () => ({ getEmail: () => 'teacher@example.com' }) },
+    ContactsApp: { getContact: jest.fn(() => ({ getFullName: () => 'T Name' })) },
     DriveApp: {
       createFolder: jest.fn(() => folder),
       getFileById: jest.fn(() => moveTarget)
@@ -172,10 +173,26 @@ test('setupInitialTeacher creates resources and stores ids', () => {
   expect(props['ABC123']).toBe('fid');
   expect(props['templateCsv_ABC123']).toBe('tplid');
   expect(userSheet.getRange).toHaveBeenCalledWith(2, 1, 1, 12);
-  expect(userRange.setValues).toHaveBeenCalled();
+  expect(userRange.setValues).toHaveBeenCalledWith([
+    [
+      'teacher@example.com',
+      'T Name',
+      'teacher',
+      0,
+      0,
+      0,
+      '',
+      expect.anything(),
+      expect.anything(),
+      1,
+      0,
+      0
+    ]
+  ]);
   const settingsSheet = sheetMap['Settings'];
   expect(settingsSheet.appendRow).toHaveBeenCalledWith(['type','value1','value2']);
   expect(settingsSheet.appendRow).toHaveBeenCalledWith(['ownerEmail', 'teacher@example.com']);
+  expect(settingsSheet.appendRow).toHaveBeenCalledWith(['ownerName', 'T Name']);
   const sheetNames = Object.keys(sheetMap);
   ['Enrollments','Tasks','Submissions','Trophies','Items','Leaderboard','Settings','TOC'].forEach(name => {
     expect(sheetNames).toContain(name);


### PR DESCRIPTION
## Summary
- automatically fetch teacher name from Contacts when setting up a teacher
- save teacher name to Global_Users and Settings
- remove name input from login screen
- test automatic name retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684941e32dc0832bb7342aaa541398be