### PR TITLE
Remove obsolete GLOBAL_DB_ID constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@
 2.  **グローバルDBの初期化:**
     * Apps Script エディタで **Setup.gs** の `initGlobalDb` を実行し、`StudyQuest_Global_Master_DB` スプレッドシートを作成します。
     * 生成されたスプレッドシートIDは `Global_Master_DB` プロパティに保存されます。
-    * 旧バージョンから移行する場合、スクリプトプロパティ `GLOBAL_DB_ID` が残っていれば手動で削除してください。
     * 作成後、実行したユーザーが編集権限を持ち、`Global_Users` シートに `admin` として登録されます。
     * そのほかの教師と共有するか、Web アプリの実行ユーザーを「自分」に設定してください。
 

--- a/src/consts.gs
+++ b/src/consts.gs
@@ -18,6 +18,5 @@ var CONSTS = (function() {
     PROP_TEACHER_PASSCODE: 'teacherPasscode',
     PROP_TEACHER_CODE_PREFIX: 'teacherCode_',
     PROP_TEACHER_SSID_PREFIX: 'ssId_',
-    PROP_GLOBAL_DB_ID: 'GLOBAL_DB_ID'
   };
 })();


### PR DESCRIPTION
## Summary
- remove unused `PROP_GLOBAL_DB_ID` constant
- clarify global DB setup docs

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494490b080832b8923b31535fb2a52