### PR TITLE
Fix clasp ignore for escapeHtml.js

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,1 +1,1 @@
-echo 'src/shared/escapeHtml.js' >> .claspignore
+src/shared/escapeHtml.js


### PR DESCRIPTION
## Summary
- correctly ignore `src/shared/escapeHtml.js` so that Apps Script deployment does not fail

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68494c1cffa8832bbe96d40ee1ebe6a0