### PR TITLE
Fix clasp ignore path

### DIFF
--- a/src/.claspignore
+++ b/src/.claspignore
@@ -1,0 +1,1 @@
+shared/escapeHtml.js

--- a/tests/.claspignore
+++ b/tests/.claspignore
@@ -1,1 +1,0 @@
-src/shared/escapeHtml.js


### PR DESCRIPTION
## Summary
- move `.claspignore` under `src`
- exclude `shared/escapeHtml.js` from Apps Script push

## Testing
- `bash scripts/setup-codex.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494f650190832bafaad64d13e203bc