### PR TITLE
Restore escapeHtml helpers

### DIFF
--- a/src/shared/escapeHtml.gs
+++ b/src/shared/escapeHtml.gs
@@ -1,0 +1,17 @@
+/**
+ * escapeHtml(text): Escape special HTML characters.
+ * @param {string} text
+ * @return {string}
+ */
+function escapeHtml(text) {
+  var map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return String(text || '').replace(/[&<>"']/g, function(m) {
+    return map[m];
+  });
+}

--- a/src/shared/escapeHtml.html
+++ b/src/shared/escapeHtml.html
@@ -1,0 +1,10 @@
+/**
+ * escapeHtml(text): Escape special HTML characters
+ * @param {string} text
+ * @return {string}
+ */
+function escapeHtml(text) {
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return text == null ? '' : String(text).replace(/[&<>"']/g, m => map[m]);
+}
+

--- a/src/shared/escapeHtml.js
+++ b/src/shared/escapeHtml.js
@@ -1,0 +1,11 @@
+/**
+ * HTML エスケープ関数（テスト用）
+ */
+module.exports = function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};


### PR DESCRIPTION
## Summary
- add shared escapeHtml utility in HTML for front-end
- add Apps Script escapeHtml helper for GAS modules
- provide Node version of escapeHtml for Jest

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849b0eaa4e0832bab8258bef9976572