### PR TITLE
Update admin setup flow

### DIFF
--- a/src/Setup.gs
+++ b/src/Setup.gs
@@ -1,5 +1,15 @@
-function quickStudyQuestSetup() {
+function quickStudyQuestSetup(passcode) {
   var props = PropertiesService.getScriptProperties();
+  var storedPass = props.getProperty(CONSTS.PROP_TEACHER_PASSCODE);
+  if (!storedPass) {
+    passcode = String(passcode || '').trim();
+    if (!passcode || !passcode.match(/^[0-9A-Za-z]+$/)) {
+      return { status: 'error', message: 'invalid_passcode' };
+    }
+    props.setProperty(CONSTS.PROP_TEACHER_PASSCODE, passcode);
+  } else {
+    passcode = storedPass;
+  }
   var driveId = props.getProperty(CONSTS.PROP_GLOBAL_DRIVE_ID);
   if (!driveId) {
     driveId = createSharedDrive_('StudyQuest');
@@ -31,6 +41,7 @@ function quickStudyQuestSetup() {
     DriveApp.getFileById(doc.getId()).moveTo(root);
   } catch (e) {}
 
+  res.passcode = passcode;
   return res;
 }
 

--- a/src/Teacher.gs
+++ b/src/Teacher.gs
@@ -98,12 +98,8 @@ function initTeacher(passcode) {
   var prefix = email.split('@')[0];
   var props = PropertiesService.getScriptProperties();
   var storedPass = props.getProperty(CONSTS.PROP_TEACHER_PASSCODE);
-  if (storedPass) {
-    if (storedPass !== passcode) {
-      return { status: 'error', message: 'パスコードが違います。' };
-    }
-  } else {
-    props.setProperty(CONSTS.PROP_TEACHER_PASSCODE, passcode);
+  if (!storedPass || storedPass !== passcode) {
+    return { status: 'error', message: 'パスコードが違います。' };
   }
 
   var stored = props.getProperty(CONSTS.PROP_TEACHER_CODE_PREFIX + email);

--- a/src/login.html
+++ b/src/login.html
@@ -32,13 +32,13 @@
         <h1 class="text-3xl font-bold tracking-widest">StudyQuest</h1>
         <p class="text-gray-400 text-sm mt-1">冒険の準備をしよう！</p>
       </div>
-      <div id="stage1" class="grid grid-cols-3 gap-4 mb-4">
+      <div id="stage1" class="grid grid-cols-2 gap-4 mb-4">
         <button id="choose-teacher" class="game-btn bg-purple-600 text-white p-3 rounded-lg font-bold border-purple-800 hover:bg-purple-500">教師</button>
         <button id="choose-student" class="game-btn bg-cyan-600 text-white p-3 rounded-lg font-bold border-cyan-800 hover:bg-cyan-500">生徒</button>
-        <button id="choose-admin" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500">admin</button>
       </div>
       <div id="teacherSection" class="space-y-4 hidden">
-        <button id="teacher-login-btn" class="game-btn bg-purple-600 text-white p-3 rounded-lg font-bold border-purple-800 hover:bg-purple-500 w-full">教師としてログイン</button>
+        <button id="teacher-login-btn" class="game-btn bg-purple-600 text-white p-3 rounded-lg font-bold border-purple-800 hover:bg-purple-500 w-full">教師として始める</button>
+        <button id="admin-start-btn" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 w-full">管理者として始める</button>
         <form id="teacher-secret-form" class="space-y-2 hidden">
           <div class="relative">
             <i data-lucide="key-round" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"></i>
@@ -93,6 +93,15 @@
     <div class="glass-panel modal rounded-2xl p-6 w-full max-w-md text-center shadow-2xl">
       <p id="welcomeText" class="mb-4"></p>
       <button id="closeWelcome" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 w-full">OK</button>
+    </div>
+  </div>
+
+  <div id="adminMessage" class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4 hidden">
+    <div class="glass-panel modal rounded-2xl p-6 w-full max-w-md text-center shadow-2xl">
+      <p class="mb-2">🎉 グローバルデータベースを作成しました！</p>
+      <p class="mb-2">秘密キー: <span id="adminPassSpan"></span></p>
+      <p class="mb-4 text-sm break-all">ログインURL: <span id="adminUrlSpan"></span></p>
+      <button id="closeAdminMsg" class="game-btn bg-indigo-600 text-white p-3 rounded-lg font-bold border-indigo-800 hover:bg-indigo-500 w-full">OK</button>
     </div>
   </div>
 
@@ -151,8 +160,8 @@
     const SCRIPT_URL = '<?!= scriptUrl.replace("/dev","/exec") ?>';
 
     const teacherBtn = document.getElementById('teacher-login-btn');
+    const adminStartBtn = document.getElementById('admin-start-btn');
     const studentBtn = document.getElementById('student-login-btn');
-    const adminBtn = document.getElementById('choose-admin');
     const secretForm = document.getElementById('teacher-secret-form');
     const stage1 = document.getElementById('stage1');
     const teacherSec = document.getElementById('teacherSection');
@@ -197,13 +206,18 @@
         .loginAsStudent();
     });
 
-    if (adminBtn) {
-      adminBtn.addEventListener('click', () => {
+    if (adminStartBtn) {
+      adminStartBtn.addEventListener('click', () => {
+        const key = prompt('教師用データベース作成の共通秘密キーを入力してください');
+        if (!key || !/^[0-9A-Za-z]+$/.test(key)) {
+          alert('半角英数字で入力してください');
+          return;
+        }
         showLoadingOverlay();
         google.script.run
           .withSuccessHandler(onAdminSetup)
           .withFailureHandler(onLoginFailure)
-          .quickStudyQuestSetup();
+          .quickStudyQuestSetup(key);
       });
     }
 
@@ -244,16 +258,8 @@
       e.preventDefault();
       const key = document.getElementById('secret-key-input').value.trim();
       if (!key) return;
-      if (key.toLowerCase() === 'admin') {
-        showLoadingOverlay();
-        google.script.run
-          .withSuccessHandler(onAdminSetup)
-          .withFailureHandler(onLoginFailure)
-          .quickStudyQuestSetup();
-      } else {
-        pendingSetupKey = key;
-        confirmModal.classList.remove('hidden');
-      }
+      pendingSetupKey = key;
+      confirmModal.classList.remove('hidden');
     });
 
     confirmYes.addEventListener('click', () => {
@@ -324,7 +330,13 @@
     function onAdminSetup(res) {
       hideLoadingOverlay();
       if (res && (res.status === 'created' || res.status === 'exists')) {
-        alert(res.status === 'created' ? 'Global DB created!' : 'Already exists');
+        document.getElementById('adminPassSpan').textContent = res.passcode || '';
+        document.getElementById('adminUrlSpan').textContent = SCRIPT_URL + '?page=login';
+        const m = document.getElementById('adminMessage');
+        m.classList.remove('hidden');
+        document.getElementById('closeAdminMsg').onclick = () => {
+          m.classList.add('hidden');
+        };
       } else {
         showError('セットアップに失敗しました');
       }

--- a/tests/Setup.test.js
+++ b/tests/Setup.test.js
@@ -29,13 +29,14 @@ test('quickStudyQuestSetup creates shared drive and moves files', () => {
   };
   loadSetup(context);
   context.initGlobalDb = jest.fn(() => ({ status: 'ok', id: 'gid' }));
-  const res = context.quickStudyQuestSetup();
+  const res = context.quickStudyQuestSetup('PASS');
   expect(driveCreate).toHaveBeenCalledWith({ name: 'StudyQuest' }, 'uuid');
   expect(props.Global_Drive_ID).toBe('did');
   expect(context.initGlobalDb).toHaveBeenCalledWith('did');
   expect(context.DriveApp.getFileById).toHaveBeenCalledWith('sid');
   expect(file.moveTo).toHaveBeenCalledWith(folder);
   expect(res.status).toBe('ok');
+  expect(res.passcode).toBe('PASS');
 });
 
 test('quickStudyQuestSetup uses existing drive', () => {
@@ -57,8 +58,9 @@ test('quickStudyQuestSetup uses existing drive', () => {
   };
   loadSetup(context);
   context.initGlobalDb = jest.fn(() => ({ status: 'ok', id: 'gid' }));
-  const res = context.quickStudyQuestSetup();
+  const res = context.quickStudyQuestSetup('PASS');
   expect(driveCreate).not.toHaveBeenCalled();
   expect(context.initGlobalDb).toHaveBeenCalledWith('did');
   expect(res.status).toBe('ok');
+  expect(res.passcode).toBe('PASS');
 });

--- a/tests/Teacher.test.js
+++ b/tests/Teacher.test.js
@@ -12,7 +12,7 @@ function loadTeacher(context) {
 }
 
 test('initTeacher creates StudyQuest_DB when none exists', () => {
-  const props = {};
+  const props = { teacherPasscode: 'PASS' };
   const dummyRange = {
     setFontWeight: jest.fn().mockReturnThis(),
     setFontSize: jest.fn().mockReturnThis(),
@@ -81,7 +81,7 @@ test('initTeacher creates StudyQuest_DB when none exists', () => {
   loadTeacher(context);
   context.getSpreadsheetByTeacherCode = () => ssStub;
   context.generateTeacherCode = jest.fn(() => 'ABC123');
-  const result = context.initTeacher();
+  const result = context.initTeacher('PASS');
   expect(result.status).toBe('new');
   expect(result.teacherCode).toBe('ABC123');
   expect(context.SpreadsheetApp.create).toHaveBeenCalledWith('StudyQuest_DB_teacher_ABC123');
@@ -178,7 +178,8 @@ test('initTeacher tasks sheet header includes draft column', () => {
   loadTeacher(context);
   context.getSpreadsheetByTeacherCode = () => ssStub;
   context.generateTeacherCode = jest.fn(() => 'ABC123');
-  context.initTeacher();
+  props.teacherPasscode = 'PASS';
+  context.initTeacher('PASS');
   const header = inserted['Tasks'].appendRow.mock.calls[0][0];
   expect(header[header.length-1]).toBe('CorrectAnswer');
 });
@@ -245,7 +246,8 @@ test('initTeacher creates Items sheet with correct header', () => {
   loadTeacher(context);
   context.getSpreadsheetByTeacherCode = () => ssStub;
   context.generateTeacherCode = jest.fn(() => 'ABC123');
-  context.initTeacher();
+  props.teacherPasscode = 'PASS';
+  context.initTeacher('PASS');
   const header = inserted['Items'].appendRow.mock.calls[0][0];
   expect(header).toEqual(['ItemID','Name','Type','Price','Effect']);
 });
@@ -312,7 +314,8 @@ test('initTeacher submissions sheet header matches README order', () => {
   loadTeacher(context);
   context.getSpreadsheetByTeacherCode = () => ssStub;
   context.generateTeacherCode = jest.fn(() => 'ABC123');
-  context.initTeacher();
+  props.teacherPasscode = 'PASS';
+  context.initTeacher('PASS');
   const header = inserted['Submissions'].appendRow.mock.calls[0][0];
   const expected = ['StudentID','TaskID','Question','StartedAt','SubmittedAt','ProductURL','QuestionSummary','AnswerSummary','EarnedXP','TotalXP','Level','Trophy','Status','LikeScore'];
   expect(header).toEqual(expected);

--- a/tests/initTeacherDrive.test.js
+++ b/tests/initTeacherDrive.test.js
@@ -13,7 +13,7 @@ function loadTeacher(context) {
 
 
 test('initTeacher returns existing code if already stored', () => {
-  const props = { ABC123: 'fid' };
+  const props = { ABC123: 'fid', teacherPasscode: 'PASS' };
   const context = {
     PropertiesService: {
       getScriptProperties: () => ({
@@ -32,6 +32,6 @@ test('initTeacher returns existing code if already stored', () => {
   loadTeacher(context);
   context.detectTeacherFolderOnDrive_ = jest.fn(() => null);
   context.findLatestFolderByName_ = jest.fn(() => ({ getDateCreated: () => new Date() }));
-  const result = context.initTeacher();
+  const result = context.initTeacher('PASS');
   expect(result).toEqual({ status: 'ok', teacherCode: 'ABC123' });
 });


### PR DESCRIPTION
## Summary
- prompt admin for teacher passcode when creating global DB
- store teacher passcode in script properties and return to client
- require passcode when initializing teacher DB
- rework login screen to offer admin setup after choosing teacher
- adjust tests for new passcode workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0d50da0c832ba7d1bbe004d6b8fa